### PR TITLE
Refactor/vuex board

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" v-if="isLoginView || jwtTokenVerified">
+  <div id="app" v-if="isLoginView || isAppReady">
     <navbar v-if="!isLoginView"/>
     <router-view></router-view>
     <foot v-if="!isLoginView"/>
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapActions } from 'vuex';
 import Vue from 'vue';
 import Navbar from './components/Navbar/Navbar';
 import Foot from './components/Foot/Foot';
@@ -23,10 +23,21 @@ export default {
     };
   },
   computed: {
-    ...mapState(['apiUrl']),
+    ...mapState([
+      'apiUrl',
+      'boardList',
+    ]),
     isLoginView() {
       return this.$route.name === 'Login';
     },
+    isAppReady() {
+      return this.jwtTokenVerified && this.boardList.length > 0;
+    },
+  },
+  methods: {
+    ...mapActions([
+      'updateBoardList',
+    ]),
   },
   mounted() {
     /* If url contains jwt info, save it into localStorage and refresh the page. */
@@ -53,6 +64,12 @@ export default {
       }).catch(() => {
         this.$router.replace('/login');
       });
+    }
+  },
+  async updated() {
+    /* Get board list only once if user is logged in. */
+    if (this.jwtTokenVerified && this.boardList.length === 0) {
+      await this.updateBoardList();
     }
   },
 };

--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -64,7 +64,7 @@ export default {
   methods: {
     ...mapActions(['fetchPost']),
     resetPost() {
-      this.fetchPost(undefined);
+      this.fetchPost(null);
     },
     logout() {
       localStorage.setItem('jwtToken', null);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,14 @@ import axios from 'axios';
 
 import { apiUrl } from '../config';
 
+
+const ALL_BOARD = {
+  id: 0,
+  ko_name: '모아보기',
+  en_name: 'all',
+};
+
+
 Vue.use(Vuex);
 
 export default new Vuex.Store({
@@ -80,7 +88,10 @@ export default new Vuex.Store({
         });
       });
     },
-    updateBoard({ commit }, board) {
+    updateBoard({ state, commit }, boardName) {
+      let board;
+      if (boardName === 'all') board = ALL_BOARD;
+      else board = state.boardList.filter(_board => _board.en_name === boardName)[0];
       commit('updateBoard', board);
     },
     updatePage({ commit }, page) {
@@ -88,12 +99,11 @@ export default new Vuex.Store({
     },
   },
   getters: {
-    boardNameList(state) {
-      const boardNameList = [];
-      state.boardList.forEach((board) => {
-        boardNameList.push(board.en_name);
-      });
-      return boardNameList;
+    getBoardNameById(state) {
+      return boardId => state.boardList.find(board => board.id === boardId).en_name;
+    },
+    getBoardIdByName(state) {
+      return boardName => state.boardList.find(board => board.en_name === boardName).id;
     },
   },
 });

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,7 +8,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    post: undefined,
+    post: null,
     apiUrl,
     board: '',
     page: 0,
@@ -31,7 +31,7 @@ export default new Vuex.Store({
   actions: {
     fetchPost({ commit }, payload) {
       if (!payload || !payload.postId) {
-        commit('updatePost', undefined);
+        commit('updatePost', null);
         return Promise.resolve();
       }
       const postId = payload.postId;
@@ -58,7 +58,7 @@ export default new Vuex.Store({
           resolve();
           // TODO: update post, page, board
         }).catch((err) => {
-          commit('updatePost', undefined);
+          commit('updatePost', null);
           reject(err);
         });
       });

--- a/src/views/Board/Board.vue
+++ b/src/views/Board/Board.vue
@@ -34,7 +34,6 @@ export default {
     ...mapState([
       'post',
       'board',
-      'boardList',
       'page',
     ]),
   },

--- a/src/views/Home/HitArticle.vue
+++ b/src/views/Home/HitArticle.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <router-link class="router-link" :to="{ name: 'PostDetail', params: { board: boardNameList[article.parent_board.id - 1], post_id: article.id }}">
+    <router-link class="router-link" :to="{ name: 'PostDetail', params: { board: getBoardNameById(article.parent_board.id), post_id: article.id }}">
       <span class="post-hit">{{ article.hit_count }}</span>
       <span class="post-title">{{ article.title }}</span>
     </router-link>
@@ -14,7 +14,7 @@
     props: ['article'],
     computed: {
       ...mapGetters([
-        'boardNameList',
+        'getBoardNameById',
       ]),
     },
   };

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script>
-import { mapState, mapActions, mapGetters } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import HitArticleList from './HitArticleList';
 import RecentArticle from './RecentArticle';
 
@@ -58,16 +58,10 @@ export default {
       'boardNameList',
     ]),
   },
-  methods: {
-    ...mapActions([
-      'updateBoardList',
-    ]),
-  },
   components: {
     HitArticleList, RecentArticle,
   },
   async mounted() {
-    await this.updateBoardList();
     this.$axios.get(`${this.apiUrl}/api/home`)
       .then((res) => {
         this.bestArticles = {

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -15,8 +15,8 @@
           <div class="column is-6" v-for="board in articles" :key="board.id">
             <hr>
             <h4 class="board-title">
-              <router-link class="board-title-router" :to="{ name: 'PostList', params: { board: boardNameList[board.id - 1] }}">
-                {{ boardNameList[board.id - 1] }}
+              <router-link class="board-title-router" :to="{ name: 'PostList', params: { board: getBoardNameById(board.id) }}">
+                {{ getBoardNameById(board.id) }}
               </router-link>
             </h4>
             <recent-article class="article-item" v-for="article in board.recent_articles" :key="article.id" :article="article"></recent-article>
@@ -55,7 +55,7 @@ export default {
       'apiUrl',
     ]),
     ...mapGetters([
-      'boardNameList',
+      'getBoardNameById',
     ]),
   },
   components: {

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -52,7 +52,6 @@ export default {
   },
   computed: {
     ...mapState([
-      'auth',
       'apiUrl',
     ]),
     ...mapGetters([

--- a/src/views/Home/RecentArticle.vue
+++ b/src/views/Home/RecentArticle.vue
@@ -15,7 +15,6 @@ export default {
   props: ['article'],
   computed: {
     ...mapState([
-      'auth',
       'apiUrl',
     ]),
     ...mapGetters([

--- a/src/views/Home/RecentArticle.vue
+++ b/src/views/Home/RecentArticle.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <router-link class="router-link" :to="{ name: 'PostDetail', params: { board: boardNameList[article.parent_board.id - 1], post_id: article.id }}">
+    <router-link class="router-link" :to="{ name: 'PostDetail', params: { board: getBoardNameById(article.parent_board.id), post_id: article.id }}">
       <span class="post-title">{{ article.title }}</span>
       <span class="post-no-comments">({{ commentNumber }})</span>
       <span class="post-time">{{ elapsedTime(article.created_at) }}</span>
@@ -18,7 +18,7 @@ export default {
       'apiUrl',
     ]),
     ...mapGetters([
-      'boardNameList',
+      'getBoardNameById',
     ]),
   },
   asyncComputed: {

--- a/src/views/PostCreate/PostCreate.vue
+++ b/src/views/PostCreate/PostCreate.vue
@@ -63,7 +63,6 @@ export default {
     ...mapState([
       'boardList',
       'apiUrl',
-      'auth',
     ]),
     ...mapState({
       defaultBoard: 'board',

--- a/src/views/PostCreate/PostCreate.vue
+++ b/src/views/PostCreate/PostCreate.vue
@@ -11,8 +11,8 @@
                 <label class="label">게시판</label>
                 <div class="control">
                   <div class="select">
-                    <select v-model="board">
-                      <option v-for="boardName in boardNameList" :selected="board === boardName">{{ boardName }}</option>
+                    <select v-model="boardName">
+                      <option v-for="board in boardList" :selected="boardName === board.en_name">{{ board.en_name }}</option>
                     </select>
                   </div>
                 </div>
@@ -45,7 +45,7 @@ import { VueEditor } from 'vue2-editor';
 export default {
   data() {
     return {
-      board: '', /* TODO: 현재 게시판 default로 설정 */
+      boardName: '',
       title: '',
       content: ' ',
       customToolbar: [
@@ -68,7 +68,8 @@ export default {
       defaultBoard: 'board',
     }),
     ...mapGetters([
-      'boardNameList',
+      'getBoardNameById',
+      'getBoardIdByName',
     ]),
   },
   components: {
@@ -92,19 +93,18 @@ export default {
           is_content_sexual: false,
           is_content_social: false,
           use_signature: false,
-          parent_board: this.boardList[this.boardNameList.indexOf(this.board)].id,
+          parent_board: this.getBoardIdByName(this.boardName),
         },
       }).then((res) => {
         this.pending = false;
-        this.$router.push(`/posts/${res.data.parent_board > 0
-          ? this.boardNameList[res.data.parent_board - 1] : 'all'}/${res.data.id}`);
+        this.$router.push(`/posts/${this.getBoardNameById(res.data.parent_board)}/${res.data.id}`);
       })
       .catch(() => {
         this.pending = false;
       });
     },
     validateInput() {
-      return this.board !== '' && this.title !== '' && this.content.trim() !== '';
+      return this.boardName !== '' && this.title !== '' && this.content.trim() !== '';
     },
     imageUploadHandler(file, Editor, cursorLocation) {
       const formData = new FormData();
@@ -125,7 +125,7 @@ export default {
     },
   },
   mounted() {
-    this.board = this.defaultBoard || this.boardNameList[0];
+    this.boardName = this.defaultBoard.en_name || this.boardList[0].en_name;
   },
 };
 </script>

--- a/src/views/PostCreate/PostCreate.vue
+++ b/src/views/PostCreate/PostCreate.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script>
-import { mapState, mapGetters, mapActions } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import { VueEditor } from 'vue2-editor';
 
 export default {
@@ -75,9 +75,6 @@ export default {
     VueEditor,
   },
   methods: {
-    ...mapActions([
-      'updateBoardList',
-    ]),
     postArticleHandler() {
       if (!this.validateInput()) {
         /* TODO: Modal로 변경 */
@@ -128,7 +125,6 @@ export default {
     },
   },
   mounted() {
-    this.updateBoardList();
     this.board = this.defaultBoard || this.boardNameList[0];
   },
 };

--- a/src/views/PostDetail/AddComment.vue
+++ b/src/views/PostDetail/AddComment.vue
@@ -129,7 +129,6 @@ export default {
     },
     addCommentHandler() {
       this.pending = true;
-      console.log(this.attachment);
       if (this.isArticle) {
         this.$axios({
           url: `${this.apiUrl}/api/comments/`,

--- a/src/views/PostDetail/AddComment.vue
+++ b/src/views/PostDetail/AddComment.vue
@@ -99,7 +99,6 @@ export default {
   computed: {
     ...mapState([
       'apiUrl',
-      'auth',
       'post',
     ]),
   },

--- a/src/views/PostDetail/Post.vue
+++ b/src/views/PostDetail/Post.vue
@@ -3,7 +3,7 @@
     <template v-if="post">
       <h1 class="title">{{ post.title }}</h1>
       <span>
-        <span class="subtitle-detail">{{ board }}</span>
+        <span class="subtitle-detail">{{ board.en_name }}</span>
         <span class="subtitle-detail">{{ post.created_by }}</span>
         <span class="subtitle-detail">{{ postCreatedAt }}</span>
       </span>

--- a/src/views/PostDetail/PostAction.vue
+++ b/src/views/PostDetail/PostAction.vue
@@ -50,7 +50,6 @@ export default {
   computed: {
     ...mapState([
       'apiUrl',
-      'auth',
       'post',
     ]),
   },

--- a/src/views/PostEdit/PostEdit.vue
+++ b/src/views/PostEdit/PostEdit.vue
@@ -77,11 +77,9 @@ export default {
           is_content_sexual: false,
           is_content_social: false,
         },
-      }).then((res) => {
+      }).then(() => {
         this.pending = false;
-        console.log(res);
         this.$router.push(`/posts/${this.getBoardNameById(this.boardId)}/${this.postId}`);
-        // console.log(result);
       })
       .catch(() => {
         this.pending = false;

--- a/src/views/PostEdit/PostEdit.vue
+++ b/src/views/PostEdit/PostEdit.vue
@@ -57,7 +57,6 @@ export default {
   computed: {
     ...mapState([
       'apiUrl',
-      'auth',
     ]),
     ...mapGetters([
       'boardNameList',

--- a/src/views/PostEdit/PostEdit.vue
+++ b/src/views/PostEdit/PostEdit.vue
@@ -51,7 +51,7 @@ export default {
       ],
       pending: false,
       postId: 0,
-      board: -1,
+      boardId: -1,
     };
   },
   computed: {
@@ -59,7 +59,7 @@ export default {
       'apiUrl',
     ]),
     ...mapGetters([
-      'boardNameList',
+      'getBoardNameById',
     ]),
   },
   components: {
@@ -80,7 +80,7 @@ export default {
       }).then((res) => {
         this.pending = false;
         console.log(res);
-        this.$router.push(`/posts/${this.board > 0 ? this.boardNameList[this.board - 1] : 'all'}/${this.postId}`);
+        this.$router.push(`/posts/${this.getBoardNameById(this.boardId)}/${this.postId}`);
         // console.log(result);
       })
       .catch(() => {
@@ -114,7 +114,7 @@ export default {
     .then((res) => {
       this.title = res.data.title;
       this.content = res.data.content;
-      this.board = res.data.parent_board.id;
+      this.boardId = res.data.parent_board.id;
     })
     .catch((err) => {
       console.log(err);

--- a/src/views/PostList/PostItem.vue
+++ b/src/views/PostList/PostItem.vue
@@ -3,7 +3,7 @@
     <td class="w-35"></td>
     <td class="w-102">{{ heading }}</td>
     <td class="w-313">
-      <router-link v-if="!post || item.id !== post.id" :to="{ name: 'PostDetail', params: { board, post_id: item.id }, query: $route.query }">
+      <router-link v-if="!post || item.id !== post.id" :to="{ name: 'PostDetail', params: { board: board.en_name, post_id: item.id }, query: $route.query }">
         {{ item.title }}
       </router-link>
     </td>

--- a/src/views/PostList/PostList.vue
+++ b/src/views/PostList/PostList.vue
@@ -74,7 +74,6 @@ export default {
       'post',
       'board',
       'page',
-      'boardList',
       'apiUrl',
     ]),
     ...mapGetters([
@@ -89,7 +88,6 @@ export default {
       'fetchPost',
       'updateBoard',
       'updatePage',
-      'updateBoardList',
     ]),
     refresh() {
       const condition = this.$route.query;
@@ -138,7 +136,6 @@ export default {
     async updatePageAndFetch(page) {
       this.isLoading = true;
       this.updatePage(page);
-      await this.updateBoardList();
       this.refresh();
     },
   },
@@ -150,7 +147,6 @@ export default {
       this.updateBoard(this.$route.params.board);
       this.updatePage(1);
     }
-    await this.updateBoardList();
     this.refresh();
   },
 };

--- a/src/views/PostList/PostList.vue
+++ b/src/views/PostList/PostList.vue
@@ -125,7 +125,7 @@ export default {
       searchTypeElement.selectedIndex = 0;
       searchInputElement.value = '';
 
-      this.fetchPost(undefined);
+      this.fetchPost(null);
       this.updatePage(1);
       this.$router.push({
         name: 'PostList',

--- a/src/views/PostList/PostList.vue
+++ b/src/views/PostList/PostList.vue
@@ -74,7 +74,6 @@ export default {
       'post',
       'board',
       'page',
-      'auth',
       'boardList',
       'apiUrl',
     ]),

--- a/src/views/PostList/PostList.vue
+++ b/src/views/PostList/PostList.vue
@@ -55,8 +55,7 @@ export default {
   },
   computed: {
     boardOrHeading() {
-      if (this.board === 'all') return '게시판';
-      return '말머리';
+      return this.board.id === 0 ? '게시판' : '말머리';
     },
     pageBase() {
       return (this.page - 1) - ((this.page - 1) % 10);
@@ -77,7 +76,7 @@ export default {
       'apiUrl',
     ]),
     ...mapGetters([
-      'boardNameList',
+      'getBoardIdByName',
     ]),
   },
   methods: {
@@ -97,7 +96,7 @@ export default {
         const key = keys[i];
         url += `${key}=${condition[key]}&`;
       }
-      if (this.board !== 'all') url += `parent_board=${this.boardNameList.indexOf(this.board) + 1}&`;
+      if (this.board.en_name !== 'all') url += `parent_board=${this.board.id}&`;
       url += `page=${this.page}`;
 
       this.$axios.get(`${this.apiUrl}/api/articles/${url}`)
@@ -129,7 +128,7 @@ export default {
       this.updatePage(1);
       this.$router.push({
         name: 'PostList',
-        params: { board: this.board },
+        params: { board: this.board.en_name },
         query,
       });
     },
@@ -143,7 +142,7 @@ export default {
     PostItem,
   },
   async mounted() {
-    if (this.board !== this.$route.params.board) {
+    if (this.board.en_name !== this.$route.params.board) {
       this.updateBoard(this.$route.params.board);
       this.updatePage(1);
     }

--- a/src/views/Setting/Setting.vue
+++ b/src/views/Setting/Setting.vue
@@ -133,11 +133,9 @@ export default {
           'Content-Type': 'multipart/form-data',
         },
         data: formData,
-      }).then((res) => {
+      }).then(() => {
         this.pending = false;
         this.showModal = true;
-        // floating
-        console.log(res);
       })
       .catch(() => {
         this.pending = false;

--- a/src/views/Setting/Setting.vue
+++ b/src/views/Setting/Setting.vue
@@ -106,7 +106,6 @@ export default {
   computed: {
     ...mapState([
       'apiUrl',
-      'auth',
     ]),
     ...mapGetters([
       'boardNameList',

--- a/src/views/Setting/Setting.vue
+++ b/src/views/Setting/Setting.vue
@@ -87,7 +87,7 @@
 
 
 <script>
-import { mapState, mapGetters } from 'vuex';
+import { mapState } from 'vuex';
 
 export default {
   data() {
@@ -106,9 +106,6 @@ export default {
   computed: {
     ...mapState([
       'apiUrl',
-    ]),
-    ...mapGetters([
-      'boardNameList',
     ]),
   },
   methods: {


### PR DESCRIPTION
vuex state 중 board에 대한 내용을 전체적으로 리팩토링 했습니다.

1. board의 가장 큰 문제점은 board가 서버에서 받아온 board 객체가 아니라 board의 en_name을 들고 있었던 점입니다. 이로 인해 en_name을 통해 board 객체를 얻어와야 하는 상황이 다수 발생했고, 별로 바람직하지 않다고 생각했습니다. 따라서 board가 en_name이 아닌 board 객체 자체를 들고 있도록 변경했습니다.
2. 1번의 연장선에서, 기존에 board의 en_name나 id를 board라는 변수명으로 들고 있던 경우가 많아 코드를 읽기 매우 어려웠습니다. 따라서 이를 전부 구분해 board 객체는 board, board의 en_name은 boardName, board의 id는 boardId라는 변수로 들고 있도록 변경했습니다.
3. 1, 2번으로 인해 getter 중 boardNameList가 굳이 필요없게 되어 삭제했습니다. 대신, url에서 현재 board를 가져올 때에는 반드시 board의 en_name을 가져올 수 밖에 없으므로 boardName을 boardId로 변환하거나 boardId를 boardName으로 변환하는 getter를 두었습니다(getBoardIdByName, getBoardNameById).


이외에 
1. post가 비었다는 것을 표현하기 위해서 undefined 대신 null을 사용하였고,
2. auth가 vuex state에서 제외된 지 좀 됐는데 아직도 코드에 남아있어서 이를 삭제했습니다.