### PR TITLE
Fix 401 issue on safari.

### DIFF
--- a/src/api/post.js
+++ b/src/api/post.js
@@ -77,7 +77,7 @@ export const uploadAttachments = (attachments) => {
 export const getAttachmentUrls = ( attachmentIds ) => {
   const promises = []
   attachmentIds.forEach((id) => {
-    promises.push(http.get(`attachments/${id}`))
+    promises.push(http.get(`attachments/${id}/`))
   })
   return Promise.all(promises)
 }

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -1,4 +1,4 @@
-import { fetchMe, fetchUser, updateDarkMode } from '@/api'
+import { fetchMe, updateDarkMode } from '@/api'
 
 const setDarkMode = (darkMode) => {
   localStorage.darkMode = darkMode


### PR DESCRIPTION
#96 
API url 에서 맨 뒤에 '/' 가 없으면 301 redirect 을 해주는데, 이 과정에서 safari 는 token 헤더가 날아가면서 생기는 이슈였습니다. 크롬은 직접 헤더를 유지하면서 redirection 을 해서 해당 버그가 발생하지 않았습니다. 추가적으로 redirection 비용도 줄어들어 매우 미미하지만 성능 향상도 기대할 수 있겠습니다.