### PR TITLE
Add support for adding images and beautified attachments

### DIFF
--- a/src/components/TextEditorDialog.vue
+++ b/src/components/TextEditorDialog.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="text-editor-dialog">
+    <transition name="dialog-fade">
+      <div class="text-editor-dialog__inner" v-if="shown">
+        <div class="text-editor-dialog__backdrop" @click="hideDialog()"></div>
+        <section class="dialog">
+          <header class="dialog__header">
+            <h2 class="dialog__title">
+              <slot name="title"></slot>
+            </h2>
+
+            <a class="dialog__close" @click="hideDialog()">
+              <i class="material-icons">close</i>
+            </a>
+          </header>
+
+          <div class="dialog__content">
+            <slot></slot>
+          </div>
+        </section>
+      </div>
+    </transition>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      shown: false,
+      callback: null
+    }
+  },
+
+  computed: {
+    dialogShown () {
+      return this.shown
+    }
+  },
+
+  methods: {
+    showDialog (callback) {
+      this.shown = true
+      this.callback = callback
+    },
+
+    hideDialog (...args) {
+      this.shown = false
+      this.callback(...args)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.dialog {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  max-width: 100%;
+  max-height: 100%;
+  transform: translate(-50%, -50%);
+  background: #f1f2f3;
+
+  // Prevents useless line wrapping bug caused by optimizeLegibility
+  text-rendering: auto;
+
+  &__header {
+    padding: 5px 20px;
+    background: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__title {
+    color: var(--text);
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  &__content {
+    padding: 0 20px;
+    padding-top: 20px;
+  }
+
+  &__close {
+    cursor: pointer;
+  }
+}
+
+.text-editor-dialog {
+  &__inner {
+    position: fixed;
+    z-index: 30;
+  }
+
+  &__backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, .8);
+  }
+}
+
+.dialog-fade {
+  &-enter-active, &-leave-active {
+    transition: opacity var(--duration) var(--background-timing);
+  }
+
+  &-enter {
+    opacity: 0;
+  }
+
+  &-leave-to {
+    opacity: 0;
+  }
+}
+</style>

--- a/src/components/TheAttachments.vue
+++ b/src/components/TheAttachments.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="attachments">
+    <h2 class="attachments-title">{{$t('upload')}}</h2>
+    <label class="dropzone"
+      :class="{
+        'dropzone-failed': dropzoneFailedReason,
+        'dropzone-enabled': dropzoneEnabled
+      }"
+      @dragover.stop.prevent="dropzoneEnabled = true"
+      @dragleave.stop.prevent="dropzoneEnabled = false"
+      @drop="handleDropUpload">
+      
+      <input class="dropzone-upload" type="file" ref="upload" @change="handleDialogUpload">
+      {{dropzoneMessage}}
+    </label>
+    
+    <div class="attachments-filelist">
+      <div class="attachments-file" v-for="file in files">
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  const ALLOWED_EXTENSIONS = [
+    'txt', 'docx', 'doc', 'pptx', 'ppt', 'pdf', 'hwp', 'zip', '7z'
+  ]
+  
+  export default {
+    data() {
+      return {
+        dropzoneFailedReason: null,
+        dropzoneEnabled: false,
+        files: []
+      }
+    },
+    
+    computed: {
+      dropzoneMessage() {
+        if(this.dropzoneFailedReason)
+          return this.$t(this.dropzoneFailedReason)
+        
+        if(this.dropzoneEnabled)
+          return this.$t('dropzone-drop')
+        
+        return this.$t('dropzone-normal')
+      }
+    },
+    
+    methods: {
+      handleDropUpload() {
+        
+      },
+      
+      handleDialogUpload() {
+        
+      }
+    }
+  }
+</script>
+
+<i18n>
+  ko:
+    upload: '첨부파일'
+    dropzone-normal: '여기를 클릭하거나 파일을 드래그 앤 드롭해주세요.'
+    dropzone-drop: '여기에 드롭해주세요.'
+    dropzone-unallowed-extensions: '허용되지 않은 확장자입니다.'
+  
+  en:
+    upload: 'Upload Attachments'
+    dropzone-normal: 'Please click here or drag &amp; drop the files.'
+    dropzone-drop: 'Please drop here.'
+    dropzone-unallowed-extensions: 'This file type is not allowed.'
+</i18n>
+
+<style lang="scss" scoped>
+  .attachments {
+    &-title {
+      color: var(--text);
+      font-size: 1.2rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+    }
+  }
+  
+  .dropzone {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    
+    background: #f1f2f3;
+    padding: 20px 0;
+    
+    color: var(--text);
+    font-size: 1rem;
+    
+    &-failed {
+      
+    }
+    
+    &-enabled {
+      
+    }
+    
+    &-upload {
+      position: absolute;
+      width: 0;
+      height: 0;
+      visibility: hidden;
+    }
+  }
+</style>

--- a/src/components/TheAttachments.vue
+++ b/src/components/TheAttachments.vue
@@ -1,62 +1,132 @@
 <template>
   <div class="attachments">
-    <h2 class="attachments-title">{{$t('upload')}}</h2>
-    <label class="dropzone"
+    <h2 class="attachments__title">{{$t('upload')}}</h2>
+    <label class="attachments__dropzone dropzone"
       :class="{
-        'dropzone-failed': dropzoneFailedReason,
-        'dropzone-enabled': dropzoneEnabled
+        'dropzone--failed': dropzoneFailedReason,
+        'dropzone--enabled': dropzoneEnabled
       }"
       @dragover.stop.prevent="dropzoneEnabled = true"
       @dragleave.stop.prevent="dropzoneEnabled = false"
-      @drop="handleDropUpload">
-      
-      <input class="dropzone-upload" type="file" ref="upload" @change="handleDialogUpload">
+      @drop.stop.prevent="handleDropUpload">
+
+      <input class="dropzone__upload" type="file" ref="upload" @change="handleDialogUpload">
       {{dropzoneMessage}}
     </label>
-    
-    <div class="attachments-filelist">
-      <div class="attachments-file" v-for="file in files">
+
+    <transition-group class="attachments__filelist" name="filelist-fade" tag="div">
+      <div class="attachments__file file" v-for="file in files" :key="file.key" @click="deleteFile(file)">
+        <img class="file__thumbnail" v-if="file.type === 'image'" :src="file.blobUrl">
+
+        <div class="file__details">
+          {{file.name}}
+
+          <i class="material-icons">delete_outline</i>
+        </div>
       </div>
-    </div>
+    </transition-group>
   </div>
 </template>
 
 <script>
-  const ALLOWED_EXTENSIONS = [
-    'txt', 'docx', 'doc', 'pptx', 'ppt', 'pdf', 'hwp', 'zip', '7z'
-  ]
-  
-  export default {
-    data() {
-      return {
-        dropzoneFailedReason: null,
-        dropzoneEnabled: false,
-        files: []
-      }
-    },
-    
-    computed: {
-      dropzoneMessage() {
-        if(this.dropzoneFailedReason)
-          return this.$t(this.dropzoneFailedReason)
-        
-        if(this.dropzoneEnabled)
-          return this.$t('dropzone-drop')
-        
-        return this.$t('dropzone-normal')
-      }
-    },
-    
-    methods: {
-      handleDropUpload() {
-        
-      },
-      
-      handleDialogUpload() {
-        
-      }
+const ALLOWED_EXTENSIONS = [
+  'txt', 'docx', 'doc', 'pptx', 'ppt', 'pdf', 'hwp', 'zip', '7z',
+  'png', 'jpg'
+]
+
+export default {
+  data () {
+    return {
+      dropzoneFailedReason: null,
+      dropzoneEnabled: false,
+      files: []
     }
+  },
+
+  computed: {
+    dropzoneMessage () {
+      if (this.dropzoneFailedReason) {
+        return this.$t(this.dropzoneFailedReason)
+      }
+
+      if (this.dropzoneEnabled) {
+        return this.$t('dropzone-drop')
+      }
+
+      return this.$t('dropzone-normal')
+    }
+  },
+
+  methods: {
+    handleUpload (fileList) {
+      const files = [...fileList]
+      const [success, error] = files.reduce(([success, error], file) => {
+        const extension = file.name.split('.').pop()
+        const uploadObject = {
+          key: Math.random().toString(36).slice(2),
+          type: file.type.split('/')[0],
+          name: file.name,
+          file
+        }
+
+        if (!ALLOWED_EXTENSIONS.includes(extension)) {
+          error.push(uploadObject)
+          return [success, error]
+        }
+
+        if (uploadObject.type === 'image') {
+          uploadObject.blobUrl = URL.createObjectURL(file)
+        }
+
+        success.push(uploadObject)
+        return [success, error]
+      }, [[], []])
+
+      if (error.length > 0) {
+        this.dropzoneFailedReason = 'dropzone-unallowed-extensions'
+        setTimeout(() => { this.dropzoneFailedReason = null }, 1500)
+      }
+
+      this.files.push(...success)
+      this.$emit('change', this.files)
+    },
+
+    handleDropUpload (event) {
+      this.dropzoneEnabled = false
+
+      if (!event.dataTransfer) return
+
+      const { dataTransfer } = event
+      this.handleUpload(dataTransfer.files)
+    },
+
+    handleDialogUpload (event) {
+      const files = this.$refs.upload.files
+      if (!files) return
+
+      this.handleUpload(files)
+    },
+
+    deleteFile (file) {
+      const index = this.files.indexOf(file)
+      this.files.splice(index, 1)
+
+      if (file.blobUrl) {
+        URL.revokeObjectURL(file.blobUrl)
+      }
+
+      this.$emit('delete', file)
+    }
+  },
+
+  destroyed () {
+    this.files.forEach(file => {
+      if (file.blobUrl) {
+        URL.revokeObjectURL(file.blobUrl)
+      }
+    })
   }
+}
 </script>
 
 <i18n>
@@ -65,7 +135,7 @@
     dropzone-normal: '여기를 클릭하거나 파일을 드래그 앤 드롭해주세요.'
     dropzone-drop: '여기에 드롭해주세요.'
     dropzone-unallowed-extensions: '허용되지 않은 확장자입니다.'
-  
+
   en:
     upload: 'Upload Attachments'
     dropzone-normal: 'Please click here or drag &amp; drop the files.'
@@ -74,40 +144,110 @@
 </i18n>
 
 <style lang="scss" scoped>
-  .attachments {
-    &-title {
-      color: var(--text);
-      font-size: 1.2rem;
-      font-weight: 700;
-      margin-bottom: 1rem;
-    }
-  }
-  
-  .dropzone {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    
-    background: #f1f2f3;
-    padding: 20px 0;
-    
+.attachments {
+  width: 60%;
+  margin-bottom: 40px;
+
+  &__title {
     color: var(--text);
-    font-size: 1rem;
-    
-    &-failed {
-      
-    }
-    
-    &-enabled {
-      
-    }
-    
-    &-upload {
+    font-size: 1.2rem;
+    font-weight: 700;
+    margin-bottom: 30px;
+  }
+
+  &__filelist {
+    position: relative;
+    margin-top: 5px;
+  }
+}
+
+.dropzone {
+  display: block;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+  text-align: center;
+  padding: 20px 40px;
+  width: 100%;
+
+  color: var(--text);
+  font-size: 1rem;
+  font-weight: 500;
+  transition: all var(--duration) var(--background-timing);
+
+  &--failed {
+    // Didn't use --theme-red as it is "theme" color, not error color
+    border-color: #ed3a3a;
+    background: #ed3a3a;
+    color: #f1f2f3;
+  }
+
+  &--enabled {
+    border-color: rgba(0, 0, 0, 0.7);
+  }
+
+  &__upload {
+    position: absolute;
+    width: 0;
+    height: 0;
+    visibility: hidden;
+  }
+}
+
+.file {
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 20px;
+  background: #fafbfc;
+  transition: background var(--duration) var(--background-timing);
+  width: 100%;
+
+  &__thumbnail {
+    max-width: 300px;
+    max-height: 100px;
+    object-fit: cover;
+    margin-bottom: 10px;
+  }
+
+  &__details {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &:hover {
+    background: #f1f2f3;
+  }
+}
+
+.filelist-fade {
+  &-enter {
+    transform: translate(-20px);
+    opacity: 0;
+  }
+
+  &-leave {
+    &-active {
       position: absolute;
-      width: 0;
-      height: 0;
-      visibility: hidden;
+    }
+
+    &-to {
+      transform: translate(20px);
+      opacity: 0;
     }
   }
+
+  &-enter-active, &-leave-active, &-move {
+    transition: all var(--duration) var(--background-timing);
+  }
+}
+
+@media (max-width: 768px) {
+  .attachments {
+    width: 100%;
+  }
+
+  .file__thumbnail {
+    max-width: none;
+  }
+}
 </style>

--- a/src/components/TheAttachments.vue
+++ b/src/components/TheAttachments.vue
@@ -29,6 +29,8 @@
 </template>
 
 <script>
+import { getAttachmentUrls } from '@/api'
+
 const ALLOWED_EXTENSIONS = [
   'txt', 'docx', 'doc', 'pptx', 'ppt', 'pdf', 'hwp', 'zip', '7z',
   'png', 'jpg'
@@ -70,9 +72,20 @@ export default {
   },
 
   methods: {
-    init (attachmentIds) {
-      attachmentIds.forEach(id => {
-        // TODO
+    async init (attachmentIds) {
+      const attachmentInfo = await getAttachmentUrls(attachmentIds)
+      attachmentInfo.forEach(({ data: info }) => {
+        const name = new URL(info.file).pathname.split('/').pop()
+        const type = info.mimetype.split('/')[0]
+
+        this.files.push({
+          key: `${info.id}`,
+          type,
+          name,
+          url: info.file,
+          blobUrl: type === 'image' ? info.file : null,
+          uploaded: true
+        })
       })
     },
 

--- a/src/components/TheAttachments.vue
+++ b/src/components/TheAttachments.vue
@@ -34,6 +34,18 @@ const ALLOWED_EXTENSIONS = [
   'png', 'jpg'
 ]
 
+/*
+* UploadObject {
+*   key: String, Random string if it is local, S3 id if is remote
+*   name: String, file name
+*   type: String, mime type before the slash
+*   uploaded: Boolean, true if it is remote, false if it is local
+*   file?: File, exists only if it is local
+*   url?: String, url of file if it is remote
+*   blobUrl?: String, url of thumbnail if it is image file
+* }
+*/
+
 export default {
   data () {
     return {
@@ -58,6 +70,12 @@ export default {
   },
 
   methods: {
+    init (attachmentIds) {
+      attachmentIds.forEach(id => {
+        // TODO
+      })
+    },
+
     handleUpload (fileList) {
       const files = [...fileList]
       const [success, error] = files.reduce(([success, error], file) => {
@@ -66,7 +84,8 @@ export default {
           key: Math.random().toString(36).slice(2),
           type: file.type.split('/')[0],
           name: file.name,
-          file
+          file,
+          uploaded: false
         }
 
         if (!ALLOWED_EXTENSIONS.includes(extension)) {
@@ -88,7 +107,7 @@ export default {
       }
 
       this.files.push(...success)
-      this.$emit('change', this.files)
+      this.$emit('add', success)
     },
 
     handleDropUpload (event) {

--- a/src/components/TheAttachments.vue
+++ b/src/components/TheAttachments.vue
@@ -33,7 +33,7 @@ import { getAttachmentUrls } from '@/api'
 
 const ALLOWED_EXTENSIONS = [
   'txt', 'docx', 'doc', 'pptx', 'ppt', 'pdf', 'hwp', 'zip', '7z',
-  'png', 'jpg'
+  'png', 'jpg', 'jpeg', 'gif'
 ]
 
 /*
@@ -75,7 +75,7 @@ export default {
     async init (attachmentIds) {
       const attachmentInfo = await getAttachmentUrls(attachmentIds)
       attachmentInfo.forEach(({ data: info }) => {
-        const name = new URL(info.file).pathname.split('/').pop()
+        const name = decodeURIComponent(new URL(info.file).pathname.split('/').pop())
         const type = info.mimetype.split('/')[0]
 
         this.files.push({

--- a/src/components/ThePostDetail.vue
+++ b/src/components/ThePostDetail.vue
@@ -53,6 +53,7 @@
     <div class="content">
       <TextEditor :editable="editable" :content="post.content"/>
     </div>
+
     <div v-if="pictureUrls && pictureUrls.length !== 0">
       <img
         v-for="url in pictureUrls"
@@ -184,7 +185,7 @@ export default {
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  
+
   .post-author-profile-picture {
     width: 25px;
     height: 25px;

--- a/src/components/ThePostWrite.vue
+++ b/src/components/ThePostWrite.vue
@@ -51,8 +51,8 @@
       <Attachments
         ref="attachments"
         multiple
-        @change="setAttachments"
-        @delete="checkIsImageAndDelete">
+        @add="addAttachments"
+        @delete="deleteAttachment">
       </Attachments>
     </div>
     <button
@@ -78,7 +78,7 @@ export default {
       boardId: '',
       title: '',
       content: '',
-      attachment: null
+      attachments: []
     }
   },
   computed: {
@@ -100,6 +100,9 @@ export default {
       this.boardId = this.post.parent_board.id
       this.title = this.post.title
       this.content = this.post.content
+      this.attachments = this.post.attachments
+
+      this.$refs.attachments.init(this.attachments)
     }
     const { board_slug: boardSlug } = this.$route.query
     if (boardSlug) {
@@ -112,26 +115,43 @@ export default {
       this.$refs.attachments.handleUpload(files)
     },
 
-    setAttachments (e) {
-      const attachments = e
-      this.attachments = attachments.map(v => v.files)
+    addAttachments (attachments) {
+      this.attachments = this.attachments.concat(attachments)
+
+      attachments.forEach(file => {
+        if (file.type === 'image') {
+          this.$refs.textEditor.addImageByFile(file)
+        }
+      })
     },
 
-    checkIsImageAndDelete (file) {
-      
+    deleteAttachment (file) {
+      if (file.uploaded) {
+        // TODO delete file from server
+      }
+
+      if (file.type === 'image') {
+        this.$refs.textEditor.removeImageByFile(file)
+      }
     },
 
     savePostByThePostWrite () {
       const { title, boardId, attachments } = this
-      const content = this.$refs.textEditor.getContent()
       this.$emit('save-post',
         {
           title,
-          content,
           boardId,
           attachments
         }
       )
+    },
+
+    updateAttachments (attachmentUpdate) {
+      this.$refs.textEditor.applyImageUpload(attachmentUpdate)
+    },
+
+    getContent () {
+      return this.$refs.textEditor.getContent()
     }
   },
   components: { Attachments, TextEditor }

--- a/src/components/ThePostWrite.vue
+++ b/src/components/ThePostWrite.vue
@@ -78,7 +78,8 @@ export default {
       boardId: '',
       title: '',
       content: '',
-      attachments: []
+      attachments: [],
+      loaded: true
     }
   },
   computed: {
@@ -100,9 +101,7 @@ export default {
       this.boardId = this.post.parent_board.id
       this.title = this.post.title
       this.content = this.post.content
-      this.attachments = this.post.attachments
-
-      this.$refs.attachments.init(this.attachments)
+      this.loaded = false
     }
     const { board_slug: boardSlug } = this.$route.query
     if (boardSlug) {
@@ -110,6 +109,16 @@ export default {
       this.boardId = this.getIdBySlug(boardSlug)
     }
   },
+
+  async mounted () {
+    if (this.post) {
+      await this.$refs.attachments.init(this.post.attachments)
+      this.attachments = this.$refs.attachments.files
+    }
+
+    this.loaded = true
+  },
+
   methods: {
     attachFiles (files) {
       this.$refs.attachments.handleUpload(files)
@@ -128,6 +137,7 @@ export default {
     deleteAttachment (file) {
       if (file.uploaded) {
         // TODO delete file from server
+        this.attachments = this.attachments.filter(v => v.key !== file.key)
       }
 
       if (file.type === 'image') {
@@ -136,6 +146,12 @@ export default {
     },
 
     savePostByThePostWrite () {
+      if (!this.loaded) {
+        // TODO add error support
+        alert("Please wait for a sec!")
+        return
+      }
+
       const { title, boardId, attachments } = this
       this.$emit('save-post',
         {

--- a/src/components/ThePostWrite.vue
+++ b/src/components/ThePostWrite.vue
@@ -47,11 +47,11 @@
     </div>
 
     <div class="attachment-input">
-      <input
-        type="file"
+      <Attachments
+        ref="attachments"
         multiple
-        @change="attachFiles"
-      />
+        @change="attachFiles">
+      </Attachments>
     </div>
     <button
       @click="savePostByThePostWrite"
@@ -65,6 +65,7 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex'
+import Attachments from '../components/TheAttachments'
 import TextEditor from '../components/TheTextEditor'
 
 export default {
@@ -106,7 +107,8 @@ export default {
   },
   methods: {
     attachFiles (e) {
-      this.attachments = [...e.target.files]
+      const attachments = e
+      this.attachments = attachments.map(v => v.files)
     },
     savePostByThePostWrite () {
       const { title, boardId, attachments } = this
@@ -121,7 +123,7 @@ export default {
       )
     }
   },
-  components: { TextEditor }
+  components: { Attachments, TextEditor }
 }
 </script>
 

--- a/src/components/ThePostWrite.vue
+++ b/src/components/ThePostWrite.vue
@@ -43,6 +43,7 @@
         ref="textEditor"
         editable="true"
         :content="initialPostContent"
+        @attach-files="attachFiles"
       />
     </div>
 
@@ -50,7 +51,8 @@
       <Attachments
         ref="attachments"
         multiple
-        @change="attachFiles">
+        @change="setAttachments"
+        @delete="checkIsImageAndDelete">
       </Attachments>
     </div>
     <button
@@ -65,8 +67,8 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex'
-import Attachments from '../components/TheAttachments'
-import TextEditor from '../components/TheTextEditor'
+import Attachments from '@/components/TheAttachments'
+import TextEditor from '@/components/TheTextEditor'
 
 export default {
   name: 'the-post-write',
@@ -106,10 +108,19 @@ export default {
     }
   },
   methods: {
-    attachFiles (e) {
+    attachFiles (files) {
+      this.$refs.attachments.handleUpload(files)
+    },
+
+    setAttachments (e) {
       const attachments = e
       this.attachments = attachments.map(v => v.files)
     },
+
+    checkIsImageAndDelete (file) {
+      
+    },
+
     savePostByThePostWrite () {
       const { title, boardId, attachments } = this
       const content = this.$refs.textEditor.getContent()

--- a/src/components/ThePostWrite.vue
+++ b/src/components/ThePostWrite.vue
@@ -78,7 +78,6 @@ export default {
       boardId: '',
       title: '',
       content: '',
-      attachments: [],
       loaded: true
     }
   },
@@ -113,7 +112,6 @@ export default {
   async mounted () {
     if (this.post) {
       await this.$refs.attachments.init(this.post.attachments)
-      this.attachments = this.$refs.attachments.files
     }
 
     this.loaded = true
@@ -125,8 +123,6 @@ export default {
     },
 
     addAttachments (attachments) {
-      this.attachments = this.attachments.concat(attachments)
-
       attachments.forEach(file => {
         if (file.type === 'image') {
           this.$refs.textEditor.addImageByFile(file)
@@ -137,7 +133,6 @@ export default {
     deleteAttachment (file) {
       if (file.uploaded) {
         // TODO delete file from server
-        this.attachments = this.attachments.filter(v => v.key !== file.key)
       }
 
       if (file.type === 'image') {
@@ -152,12 +147,12 @@ export default {
         return
       }
 
-      const { title, boardId, attachments } = this
+      const { title, boardId } = this
       this.$emit('save-post',
         {
           title,
           boardId,
-          attachments
+          attachments: this.$refs.attachments.files
         }
       )
     },

--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="editor">
+  <div class="editor" :class="{'editor--editable': this.editable}">
     <EditorMenuBar :editor="editor" v-show="this.editable">
       <div
         class="editor-menu-bar"
@@ -211,11 +211,7 @@ export default {
 </style>
 
 <style lang="scss">
-.editor-content {
-  img {
-    &.ProseMirror-selectednode {
-      filter: brightness(.5);
-    }
-  }
+.editor--editable .editor-content img.ProseMirror-selectednode {
+  filter: brightness(.5);
 }
 </style>

--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="editor">
-    <editor-menu-bar :editor="editor" v-show="this.editable">
+    <EditorMenuBar :editor="editor" v-show="this.editable">
       <div
         class="editor-menu-bar"
         slot-scope="{ commands, isActive }"
@@ -27,6 +27,15 @@
 
         <button
           class="menubar__button"
+          @click="showImageDialog(commands.image)"
+        >
+          <span class="icon">
+            <i class="material-icons">image</i>
+          </span>
+        </button>
+
+        <button
+          class="menubar__button"
           :class="{ 'is-active': isActive.code() }"
           @click="commands.code"
         >
@@ -35,9 +44,13 @@
           </span>
         </button>
       </div>
-    </editor-menu-bar>
+    </EditorMenuBar>
     <div class="content">
-      <editor-content :editor="editor" class="editor-content" />
+      <EditorContent :editor="editor" class="editor-content" />
+    </div>
+
+    <div class="dialogs">
+      <TheTextEditorImageDialog ref="imageDialog" @attach-files="attachFiles" />
     </div>
   </div>
 </template>
@@ -48,8 +61,11 @@ import {
   Bold,
   Code,
   Heading,
+  History,
+  Image,
   Placeholder
 } from 'tiptap-extensions'
+import TheTextEditorImageDialog from '@/components/TheTextEditorImageDialog'
 
 export default {
   name: 'the-text-editor',
@@ -61,6 +77,8 @@ export default {
           new Bold(),
           new Code(),
           new Heading({ levels: [1] }),
+          new History(),
+          new Image(),
           new Placeholder({
             emptyNodeClass: 'is-empty',
             emptyNodeText: 'Write something …',
@@ -72,17 +90,34 @@ export default {
       })
     }
   },
+
   methods: {
     getContent () {
       return this.editor.getHTML()
+    },
+
+    showImageDialog (callback) {
+      this.$refs.imageDialog.showDialog(imageUrl => {
+        if (imageUrl) {
+          const result = callback({ src: imageUrl })
+          console.log(result)
+        }
+      })
+    },
+
+    attachFiles (files) {
+      this.$emit('attach-files', files)
     }
   },
+
   beforeDestroy () {
     this.editor.destroy()
   },
+
   components: {
     EditorContent,
-    EditorMenuBar
+    EditorMenuBar,
+    TheTextEditorImageDialog
   }
 }
 </script>
@@ -134,4 +169,14 @@ export default {
   }
 }
 
+</style>
+
+<style lang="scss">
+.editor-content {
+  img {
+    &.ProseMirror-selectednode {
+      filter: brightness(.5);
+    }
+  }
+}
 </style>

--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -96,10 +96,10 @@ export default {
       return this.editor.getHTML()
     },
 
-    showImageDialog (callback) {
+    showImageDialog (command) {
       this.$refs.imageDialog.showDialog(imageUrl => {
         if (imageUrl) {
-          callback({ src: imageUrl })
+          command({ src: imageUrl })
         }
       })
     },
@@ -118,7 +118,7 @@ export default {
     },
 
     removeImageByFile (file) {
-      let imagePosition = null;
+      let imagePosition = null
 
       this.editor.state.doc.descendants((node, pos) => {
         if (imagePosition !== null) return false

--- a/src/components/TheTextEditorImageDialog.vue
+++ b/src/components/TheTextEditorImageDialog.vue
@@ -1,0 +1,136 @@
+<template>
+  <TextEditorDialog class="image-dialog" ref="root">
+    <span slot="title">
+      {{$t('image-attach')}}
+    </span>
+
+    <div class="image-dialog__section">
+      <h3>{{$t('image-from-url')}}</h3>
+      <input
+        class="input" type="text" v-model="url"
+        :class="{ 'is-empty': urlEmpty }"
+        :placeholder="$t('image-url')"
+        />
+
+      <button class="button image-dialog__button" @click="hideDialog(url)">
+        {{$t('image-add')}}
+      </button>
+    </div>
+
+    <div class="image-dialog__section">
+      <h3>{{$t('image-or')}}</h3>
+      <span>{{$t('image-alternatives')}}</span>
+    </div>
+  </TextEditorDialog>
+</template>
+
+<script>
+import TextEditorDialog from '@/components/TextEditorDialog'
+
+export default {
+  data () {
+    return {
+      url: '',
+      pasteListener: null
+    }
+  },
+
+  computed: {
+    urlEmpty () {
+      return this.url.length === 0
+    }
+  },
+
+  methods: {
+    showDialog (callback) {
+      this.url = ''
+      this.$refs.root.showDialog(callback)
+
+      this.pasteListener = document.addEventListener('paste', this.pasteListener)
+    },
+
+    hideDialog (...args) {
+      this.$refs.root.hideDialog(...args)
+
+      if (this.pasteListener) {
+        document.removeEventListener('paste', this.pasteListener)
+      }
+    }
+  },
+
+  mounted () {
+    this.pasteListener = event => {
+      const dataTransfer = event.clipboardData || window.clipboardData
+      if (!dataTransfer) return
+
+      const items = [...dataTransfer.items]
+      const files = items
+        .filter(item => item.type.split('/')[0] === 'image')
+        .map(item => item.getAsFile())
+
+      if(files.length === 0) return
+
+      this.$emit('attach-files', files)
+      this.hideDialog()
+    }
+  },
+
+  beforeDestroy () {
+    if (this.pasteListener) {
+      document.removeEventListener('paste', this.pasteListener)
+    }
+  },
+
+  components: {
+    TextEditorDialog
+  }
+}
+</script>
+
+<i18n>
+ko:
+  image-attach: '이미지 첨부'
+  image-from-url: 'URL에서 가져오기'
+  image-url: 'URL'
+  image-or: '또는'
+  image-alternatives: '본문 하단의 첨부파일 칸에 추가하거나 여기에 붙여넣어서 이미지를 추가할 수도 있습니다.'
+  image-add: '추가'
+
+en:
+  image-attach: 'Add an image'
+  image-from-url: 'Import from URL'
+  image-url: 'URL'
+  image-or: 'Other Options'
+  image-add-attachment: 'Alternatively, you can add images by paste here or add it to attachments section'
+  image-add: 'Add'
+</i18n>
+
+<style lang="scss" scoped>
+.image-dialog {
+  &__section {
+    margin-bottom: 20px;
+
+    h3 {
+      background: transparent;
+      font-size: 1.2rem;
+      font-weight: 600;
+      margin-bottom: .3rem;
+    }
+  }
+
+  &__button {
+    margin-top: 5px;
+    margin-left: auto;
+    display: block;
+
+    background: var(--theme-red);
+    border: none;
+    color: #f1f2f3;
+
+    &:hover {
+      background: #dc7272;
+      color: #f1f2f3;
+    }
+  }
+}
+</style>

--- a/src/components/TheTextEditorImageDialog.vue
+++ b/src/components/TheTextEditorImageDialog.vue
@@ -63,6 +63,9 @@ export default {
       const dataTransfer = event.clipboardData || window.clipboardData
       if (!dataTransfer) return
 
+      event.preventDefault()
+      event.stopPropagation()
+
       const items = [...dataTransfer.items]
       const files = items
         .filter(item => item.type.split('/')[0] === 'image')

--- a/src/components/TheTextEditorImageDialog.vue
+++ b/src/components/TheTextEditorImageDialog.vue
@@ -71,7 +71,7 @@ export default {
         .filter(item => item.type.split('/')[0] === 'image')
         .map(item => item.getAsFile())
 
-      if(files.length === 0) return
+      if (files.length === 0) return
 
       this.$emit('attach-files', files)
       this.hideDialog()

--- a/src/editor/AttachmentImage.js
+++ b/src/editor/AttachmentImage.js
@@ -1,4 +1,4 @@
-import { Node, Plugin } from 'tiptap'
+import { Node } from 'tiptap'
 import { nodeInputRule } from 'tiptap-commands'
 
 /**
@@ -14,21 +14,20 @@ const IMAGE_INPUT_REGEX = /!\[(.+|:?)\]\((\S+)(?:(?:\s+)["'](\S+)["'])?\)/
 // Rewrite of default Image plugin of tiptap as it is hard to integrate with attachments,
 // and it handles image as data-uri when drag & drop
 export default class AttachmentImage extends Node {
-
-  get name() {
+  get name () {
     return 'attachmentImage'
   }
 
-  get schema() {
+  get schema () {
     return {
       inline: true,
       attrs: {
         src: {},
         alt: {
-          default: null,
+          default: null
         },
         title: {
-          default: null,
+          default: null
         },
         'data-attachment': {
           default: null
@@ -44,14 +43,14 @@ export default class AttachmentImage extends Node {
             title: dom.getAttribute('title'),
             alt: dom.getAttribute('alt'),
             'data-attachment': dom.getAttribute('data-attachment')
-          }),
-        },
+          })
+        }
       ],
-      toDOM: node => ['img', node.attrs],
+      toDOM: node => ['img', node.attrs]
     }
   }
 
-  commands({ type }) {
+  commands ({ type }) {
     return attrs => (state, dispatch) => {
       const { selection } = state
       const position = selection.$cursor ? selection.$cursor.pos : selection.$to.pos
@@ -61,7 +60,7 @@ export default class AttachmentImage extends Node {
     }
   }
 
-  inputRules({ type }) {
+  inputRules ({ type }) {
     return [
       nodeInputRule(IMAGE_INPUT_REGEX, type, match => {
         const [, alt, src, title] = match

--- a/src/editor/AttachmentImage.js
+++ b/src/editor/AttachmentImage.js
@@ -1,0 +1,76 @@
+import { Node, Plugin } from 'tiptap'
+import { nodeInputRule } from 'tiptap-commands'
+
+/**
+ * Matches following attributes in Markdown-typed image: [, alt, src, title]
+ *
+ * Example:
+ * ![Lorem](image.jpg) -> [, "Lorem", "image.jpg"]
+ * ![](image.jpg "Ipsum") -> [, "", "image.jpg", "Ipsum"]
+ * ![Lorem](image.jpg "Ipsum") -> [, "Lorem", "image.jpg", "Ipsum"]
+ */
+const IMAGE_INPUT_REGEX = /!\[(.+|:?)\]\((\S+)(?:(?:\s+)["'](\S+)["'])?\)/
+
+// Rewrite of default Image plugin of tiptap as it is hard to integrate with attachments,
+// and it handles image as data-uri when drag & drop
+export default class AttachmentImage extends Node {
+
+  get name() {
+    return 'attachmentImage'
+  }
+
+  get schema() {
+    return {
+      inline: true,
+      attrs: {
+        src: {},
+        alt: {
+          default: null,
+        },
+        title: {
+          default: null,
+        },
+        'data-attachment': {
+          default: null
+        }
+      },
+      group: 'inline',
+      draggable: true,
+      parseDOM: [
+        {
+          tag: 'img[src]',
+          getAttrs: dom => ({
+            src: dom.getAttribute('src'),
+            title: dom.getAttribute('title'),
+            alt: dom.getAttribute('alt'),
+            'data-attachment': dom.getAttribute('data-attachment')
+          }),
+        },
+      ],
+      toDOM: node => ['img', node.attrs],
+    }
+  }
+
+  commands({ type }) {
+    return attrs => (state, dispatch) => {
+      const { selection } = state
+      const position = selection.$cursor ? selection.$cursor.pos : selection.$to.pos
+      const node = type.create(attrs)
+      const transaction = state.tr.insert(position, node)
+      dispatch(transaction)
+    }
+  }
+
+  inputRules({ type }) {
+    return [
+      nodeInputRule(IMAGE_INPUT_REGEX, type, match => {
+        const [, alt, src, title] = match
+        return {
+          src,
+          alt,
+          title
+        }
+      })
+    ]
+  }
+}

--- a/src/views/Write.vue
+++ b/src/views/Write.vue
@@ -73,7 +73,6 @@ export default {
           })
         } catch (err) {
           /* @TODO: 에러 핸들링 */
-          console.error(err)
           alert('Failed to upload attachments!')
           this.saving = false
           return

--- a/src/views/Write.vue
+++ b/src/views/Write.vue
@@ -46,7 +46,7 @@ export default {
       if (title === '') {
         this.isTitleEmpty = true
       }
-      if (this.$refs.write.getContent() === '{"type":"doc","content":[{"type":"paragraph"}]}') {
+      if (this.$refs.write.getContent() === '<p></p>') {
         this.isContentEmpty = true
         alert('Cannot post empty article')
       }

--- a/src/views/Write.vue
+++ b/src/views/Write.vue
@@ -1,6 +1,7 @@
 <template>
   <TheLayout>
     <ThePostWrite
+      ref="write"
       v-if="postFetched"
       :post="post"
       :saving="saving"
@@ -41,11 +42,11 @@ export default {
   },
   methods: {
     async savePost (newArticle) {
-      const { title, content, boardId, attachments } = newArticle
+      const { title, boardId, attachments } = newArticle
       if (title === '') {
         this.isTitleEmpty = true
       }
-      if (content === '{"type":"doc","content":[{"type":"paragraph"}]}') {
+      if (this.$refs.write.getContent() === '{"type":"doc","content":[{"type":"paragraph"}]}') {
         this.isContentEmpty = true
         alert('Cannot post empty article')
       }
@@ -58,18 +59,31 @@ export default {
 
       this.saving = true
 
-      let attachmentIds = []
+      const uploadNeededFiles = attachments.filter(item => !item.uploaded)
+      const attachmentUpdate = {}
       if (attachments) {
         try {
-          attachmentIds = (await uploadAttachments(attachments))
-            .map(result => result.data.id)
+          const results = await uploadAttachments(uploadNeededFiles.map(v => v.file))
+
+          uploadNeededFiles.forEach((item, index) => {
+            attachmentUpdate[item.key] = results[index].data
+
+            item.uploaded = true
+            item.key = results[index].data.id
+          })
         } catch (err) {
           /* @TODO: 에러 핸들링 */
+          console.error(err)
           alert('Failed to upload attachments!')
           this.saving = false
           return
         }
       }
+
+      const attachmentIds = attachments.map(item => item.key)
+      this.$refs.write.updateAttachments(attachmentUpdate)
+
+      const content = this.$refs.write.getContent()
 
       newArticle = {
         title,


### PR DESCRIPTION
## Changes
* Beautified attachments  
Added features that enables users to upload attachments by open dialog or drag & drop

* Inline image support  
When user adds image to the attachment, click image button and embed url, or paste the images are added to the content.

* Editing attachment support  
When user edits written post, the user can add/delete attachments

## Related Issues
#64 #68 