### PR TITLE
[Issue #101] Placeholder for editor

### DIFF
--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -197,8 +197,18 @@ export default {
       }
     }
   }
+}
+</style>
 
-  p::before {
+<style lang="scss">
+.editor--editable {
+  .editor-content {
+    img.ProseMirror-selectednode {
+      filter: brightness(.5);
+    }
+  }
+  
+  p.is-empty:first-child::before {
     content: attr(data-empty-text);
     float: left;
     color: #aaa;
@@ -206,12 +216,5 @@ export default {
     height: 0;
     font-style: italic;
   }
-}
-
-</style>
-
-<style lang="scss">
-.editor--editable .editor-content img.ProseMirror-selectednode {
-  filter: brightness(.5);
 }
 </style>


### PR DESCRIPTION
Now, it shows a placeholder for editor.

### Changes
Moved some of editor style into un-scoped style as scoped style can't be applied to prosemirror-related part.

## Related Issues
#101