### PR TITLE
Update api endpoint for recent articles

### DIFF
--- a/src/api/board.js
+++ b/src/api/board.js
@@ -42,7 +42,7 @@ export const fetchRecentViewedPosts = ({ page, pageSize } = {}) => {
   if (page) context.page = page
   if (pageSize) context.page_size = pageSize
 
-  return http.get(`recents/?${queryBuilder(context)}`)
+  return http.get(`articles/recent/?${queryBuilder(context)}`)
     .then(({ data }) => data)
 }
 


### PR DESCRIPTION
api쪽 코드를 리팩토링 하여서 endpoint 주소가 변경되었습니다.

https://github.com/sparcs-kaist/new-ara-api/pull/136 과 연계된 PR입니다.