### PR TITLE
Use comment_count instead of nested_comments_count

### DIFF
--- a/src/components/BoardItem.vue
+++ b/src/components/BoardItem.vue
@@ -43,7 +43,7 @@
           {{ $t('comments') }}
         </span>
 
-        {{ elideText(post.nested_comments_count) }}
+        {{ elideText(post.comment_count) }}
       </div>
 
       <div class="post-status__view">

--- a/src/components/ThePostComments.vue
+++ b/src/components/ThePostComments.vue
@@ -17,7 +17,7 @@
       />
     </div>
 
-    <PostCommentEditor :parentArticle="postId" @upload="$emit('upload', $event)" />
+    <PostCommentEditor :parentArticle="post.id" @upload="$emit('upload', $event)" />
   </div>
 </template>
 
@@ -29,15 +29,15 @@ export default {
   name: 'the-post-comments',
 
   props: {
-    comments: { required: true },
-    postId: { required: true }
+    post: { required: true },
+    comments: { required: true }
   },
 
   computed: {
     commentCount () {
-      if (!this.comments) return 0
+      if (!this.post || !this.comments) return 0
 
-      return Object.keys(this.comments).length
+      return this.post.comment_count
     }
   },
 

--- a/src/components/ThePostHeader.vue
+++ b/src/components/ThePostHeader.vue
@@ -68,7 +68,7 @@
               {{ $t('comments') }}
             </span>
 
-            {{ post.nested_comments_count }}
+            {{ post.comment_count }}
           </div>
 
           <div class="post-header__status-item">

--- a/src/views/Post.vue
+++ b/src/views/Post.vue
@@ -24,8 +24,8 @@
     />
 
     <ThePostComments
+      :post="post"
       :comments="post.comments"
-      :postId="postId"
       @upload="addNewComment"
       @update="updateComment"
       @refresh="refresh"


### PR DESCRIPTION
기존의 article.comment_set.count() 와 article.comment_set.comment_set.count() 로 nested comment count를 가져오던 방식에서

Article 모델에 comment_count 필드를 만들고, comment가 추가될 때마다 post_save signal로 update_comment_count 함수를 실행해 comment_count 필드에 nested comment count를 저장하는 방식으로 변경합니다.

https://github.com/sparcs-kaist/new-ara-api/pull/146 에 대응되는 PR입니다.