### PR TITLE
Fix not to set NODE_ENV in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk del --purge .build-deps
 # Copy other sources
 COPY . .
 
-RUN NODE_ENV=production npm run build
+RUN npm run build
 
 FROM nginx:1.19-alpine as newara-web
 ARG WORKDIR


### PR DESCRIPTION
백엔드 서버를 dev 또는 prod를 써줄지 결정해 주기 위해서는 Dockerfile에서 NODE_ENV를 정해주지 않고, 각 서버에 있는 docker-compose에서 정해주어야 할 것 같습니다.