### PR TITLE
Fix clickable profile in anonymous board.

### DIFF
--- a/src/components/PostComment.vue
+++ b/src/components/PostComment.vue
@@ -4,7 +4,9 @@
       <img class="comment__profile" :src="profileImage" />
       <div class="comment__body">
         <div class="comment__header">
-          <router-link :to="{ name: 'user', params: { username: authorId } }" class="comment__author">
+          <router-link
+           :is="isAnonymous ? 'span' : 'router-link'"
+           :to="{ name: 'user', params: { username: authorId } }" class="comment__author">
             {{ author }}
           </router-link>
 
@@ -146,6 +148,12 @@ export default {
     isMine () {
       // return this.userNickname === this.comment.created_by.profile.nickname
       return this.comment.is_mine
+    },
+    isAnonymous () {
+      if (this.comment.is_anonymous) {
+        return true
+      }
+      return false
     }
   },
 

--- a/src/components/ThePostHeader.vue
+++ b/src/components/ThePostHeader.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="post">
     <div class="title">
-      <router-link class="title__board" :to="{
+      <router-link
+        class="title__board" :to="{
         name: 'board',
         params: { boardSlug }
       }">
@@ -30,7 +31,8 @@
       </span>
     </div>
     <div class="metadata">
-      <router-link :to="{
+      <router-link :is="isAnonymous ? 'span' : 'router-link'"
+        :to="{
         name: 'user', params: { username: postAuthorId }
       }" class="author">
         <img :src="userPictureUrl" class="author__picture"/>
@@ -92,6 +94,9 @@ export default {
       }
 
       return this.post.title
+    },
+    isAnonymous () {
+      return this.post.is_anonymous
     },
     ...mapGetters([ 'userId' ])
   },

--- a/src/components/ThePostHeader.vue
+++ b/src/components/ThePostHeader.vue
@@ -37,7 +37,7 @@
       }" class="author">
         <img :src="userPictureUrl" class="author__picture"/>
         <span class="author__nickname">{{ postAuthor }}</span>
-        <i class="author__icon material-icons">chevron_right</i>
+        <i class="author__icon material-icons" v-if="!isAnonymous">chevron_right</i>
       </router-link>
       <LikeButton class="metadata__like" :item="post" votable @vote="$emit('vote', $event)"/>
     </div>


### PR DESCRIPTION
익명 게시판에서 익명 댓글과 익명 게시글에서 프로필이 클릭되지 않도록 수정하였습니다.
다만, is_anonymous = true로 되어있는 경우에만 동작하여 익명 게시판이라도 익명이 되어있지 않은 경우에는 프로필 클릭이 가능합니다.