### PR TITLE
Fix nickname on comment editor(in anonymous board) doesn't changed by router-link.

### DIFF
--- a/src/components/PostComment.vue
+++ b/src/components/PostComment.vue
@@ -73,6 +73,7 @@
         :text="comment.content"
         :edit-comment="comment.id"
         :post="post"
+        :anonymousNickname="anonymousNickname"
         @upload="updateComment"
         @close="isEditing = false"
       />
@@ -85,6 +86,7 @@
         :key="replyComment.id"
         :comment="replyComment"
         :post="post"
+        :anonymousNickname="anonymousNickname"
         @vote="$emit('vote')"
         @delete="$emit('delete')"
         @update="$emit('update', $event)"
@@ -95,6 +97,7 @@
         <PostCommentEditor
           :post="post"
           :parent-comment="comment.id"
+          :anonymousNickname="anonymousNickname"
           ref="commentEditor"
           @upload="$emit('upload', $event)"
           @close="showReplyCommentInput = false"
@@ -118,6 +121,7 @@ export default {
   props: {
     post: { required: true },
     comment: { required: true },
+    anonymousNickname: { default: '' },
     isReplyComment: Boolean
   },
 

--- a/src/components/PostCommentEditor.vue
+++ b/src/components/PostCommentEditor.vue
@@ -6,7 +6,7 @@
         <img :src="this.post.created_by.profile.picture" class="comment-editor__picture" v-else/>
         <span class="comment-editor__name" v-if="!isAnonymous">{{ userNickname }}</span>
         <span class="comment-editor__name author_red" v-else-if="isMine">{{$t('author')}}</span>
-        <span class="comment-editor__name" v-else>{{ getAnonymousNickname }}</span>
+        <span class="comment-editor__name" v-else>{{ anonymousNickname }}</span>
       </div>
       <div class="comment-editor__content">
         <textarea
@@ -77,6 +77,11 @@ export default {
 
     editComment: {
       default: null
+    },
+
+    anonymousNickname: {
+      type: String,
+      default: ''
     }
   },
 
@@ -87,7 +92,7 @@ export default {
     isMine () {
       return this.post.is_mine
     },
-    ...mapGetters([ 'userNickname', 'userPicture', 'getAnonymousNickname' ])
+    ...mapGetters([ 'userNickname', 'userPicture' ])
   },
 
   methods: {

--- a/src/components/ThePostComments.vue
+++ b/src/components/ThePostComments.vue
@@ -42,7 +42,6 @@ export default {
     anonymousNickname () {
       let nickname = this.$t('anonymous')
       if (this.post.is_anonymous) {
-        console.log('anonymousNickname')
         // Get my anonymous nickname from post's comments
         for (var comment of this.post.comments) {
           if (comment.is_mine) {

--- a/src/components/ThePostComments.vue
+++ b/src/components/ThePostComments.vue
@@ -11,20 +11,19 @@
         :key="comment.id"
         :comment="comment"
         :post="post"
+        :anonymousNickname="anonymousNickname"
         @update="$emit('update', $event)"
         @upload="$emit('upload', $event)"
         @vote="$emit('refresh')"
         @delete="$emit('refresh')"
         class="comments__comment"
       />
-      <!--TODO: getAnonymousNickname을 이렇게 실행시키지 말고 실행시켜야 함.(불필요한 v-if연산)-->
     </div>
 
-    <PostCommentEditor :parentArticle="post.id" :post="post" @upload="$emit('upload', $event)"/>
+    <PostCommentEditor :parentArticle="post.id" :post="post" :anonymousNickname="anonymousNickname" @upload="$emit('upload', $event)"/>
   </div>
 </template>
 <script>
-import store from '@/store'
 import PostComment from '@/components/PostComment.vue'
 import PostCommentEditor from '@/components/PostCommentEditor.vue'
 
@@ -39,26 +38,27 @@ export default {
     commentCount () {
       if (!this.post || !this.comments) return 0
       return this.post.comment_count
-    }
-  },
-  beforeUpdate () {
-    // Get my anonymous nickname from post's comments
-    let nickname = this.$t('anonymous')
-    for (var comment of this.post.comments) {
-      if (comment.is_mine) {
-        nickname = comment.created_by.username
-        store.commit('setAnonymousNickname', nickname)
-        return
-      }
-      for (var replyComment in comment.comments) {
-        if (replyComment.is_mine) {
-          nickname = replyComment.created_by.username
-          store.commit('setAnonymousNickname', nickname)
-          return
+    },
+    anonymousNickname () {
+      let nickname = this.$t('anonymous')
+      if (this.post.is_anonymous) {
+        console.log('anonymousNickname')
+        // Get my anonymous nickname from post's comments
+        for (var comment of this.post.comments) {
+          if (comment.is_mine) {
+            nickname = comment.created_by.username
+            return nickname
+          }
+          for (var replyComment in comment.comments) {
+            if (replyComment.is_mine) {
+              nickname = replyComment.created_by.username
+              return nickname
+            }
+          }
         }
       }
+      return nickname
     }
-    store.commit('setAnonymousNickname', nickname)
   },
   components: {
     PostComment,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -18,8 +18,7 @@ export default new Vuex.Store({
   state: {
     boardList: [],
     recentPosts: [],
-    archivedPosts: [],
-    userAnonymousNickname: 'Anonymous'
+    archivedPosts: []
   },
   getters: {
     hasFetchedBoardList: ({ boardList }) =>
@@ -34,9 +33,7 @@ export default new Vuex.Store({
     getNameById: ({ boardList }) => (id, locale) => {
       const board = boardList.find(board => board.id === id)
       return board ? board[`${locale}_name`] : i18n.t('all', locale)
-    },
-    getAnonymousNickname: ({ userAnonymousNickname }) =>
-      userAnonymousNickname
+    }
   },
   mutations: {
     setBoardList (state, boardList) {
@@ -47,9 +44,6 @@ export default new Vuex.Store({
       state.recentPosts = posts
     },
 
-    setAnonymousNickname (state, anonymousNickname) {
-      state.userAnonymousNickname = anonymousNickname
-    },
     setArchivedPosts (state, posts) {
       state.archivedPosts = posts
     }


### PR DESCRIPTION
router-link를 통한 게시글 이동 시 사용자 이름이 바뀌지 않는 문제를 해결하였습니다.
beforeUpdate 혹은 watch가 router-link 사용 시 실행되지 않는 것이 문제였고, 

이를 해결하기 위해
기존에 store를 이용하여 anonymousNickname을 PostCommentEditor에 전달하고 있었던 것을 store를 거치지 않도록 하고,
ThePostComments에서 computed 속성을 통해 보내주도록 코드를 정리하였습니다.