### PR TITLE
Fix mobile editor bug hidden by header 

### DIFF
--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -449,6 +449,7 @@ en:
 </style>
 
 <style lang="scss">
+@import '@/theme.scss';
 .editor--editable {
   .editor-content {
     img.ProseMirror-selectednode {
@@ -458,6 +459,10 @@ en:
 
   .ProseMirror {
     min-height: 400px;
+
+    @include breakPoint(mobile) {
+      min-height: 160px;
+    }
   }
 
   p.is-empty:first-child::before {


### PR DESCRIPTION
모바일 페이지에서 가상 키보드가 올라오면서 텍스트 필드 칸을 위로 올려 보내면서 헤더 뒤에 숨겨지는 것이 원인이었는데, 필드 높이를 좀 줄여서 헤더 뒤까지 안 올라가게 수정했습니다.