### PR TITLE
Fix calling api twice in async beforeRouteEnter

### DIFF
--- a/src/router/auth.js
+++ b/src/router/auth.js
@@ -22,8 +22,8 @@ export const authGuard = async (to, from, next) => {
       } else {
         // @TODO: 서버장애 페이지..?
       }
+      next()
     }
-    next()
   }
 }
 


### PR DESCRIPTION
`Post.vue` 의 234번째 줄 `async beforeRouteEnter` 가 두번 호출되는 것 같아 원인을 찾다가, next가 두번 호출되는 부분이 있는 것 같아 고쳤습니다

https://github.com/sparcs-kaist/new-ara-web/commit/5ce6b91684a37da2a6a821b5d46db240db5aaf8#diff-d4d010a24b548119e04d67df4d76edbc44326d901f86c3946c2edbb78a2cf0af 에서 추가된 것 같은데, 혹시 저기서 추가된 이유가 따로 있을까요..?