### PR TITLE
Add Language name next to language icon

### DIFF
--- a/src/components/TermsPopup.vue
+++ b/src/components/TermsPopup.vue
@@ -15,6 +15,9 @@
             <span class="icon">
               <i class="material-icons">language</i>
             </span>
+            <span>
+              {{$t('language')}}
+            </span>
           </a>
         </div>
 
@@ -106,6 +109,7 @@ export default {
 
 <i18n>
 ko:
+  language: '한국어'
   title: '이용 약관'
   agreed: '동의하셨습니다'
   already-agreed: '이미 동의하셨습니다.'
@@ -189,6 +193,7 @@ ko:
   tos-footer: '본 약관은 2020-09-26부터 적용됩니다.'
 
 en:
+  language: 'English'
   title: 'Terms of service'
   agreed: "You've agreed to the Terms of Service"
   already-agreed: "You've already agreed."
@@ -375,6 +380,10 @@ en:
     }
 
     .toggle-language{
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 15px;
       margin-left: auto;
       margin-right: 30px;
     }

--- a/src/components/TermsPopup.vue
+++ b/src/components/TermsPopup.vue
@@ -109,7 +109,7 @@ export default {
 
 <i18n>
 ko:
-  language: '한국어'
+  language: 'English'
   title: '이용 약관'
   agreed: '동의하셨습니다'
   already-agreed: '이미 동의하셨습니다.'
@@ -193,7 +193,7 @@ ko:
   tos-footer: '본 약관은 2020-09-26부터 적용됩니다.'
 
 en:
-  language: 'English'
+  language: '한국어'
   title: 'Terms of service'
   agreed: "You've agreed to the Terms of Service"
   already-agreed: "You've already agreed."
@@ -381,7 +381,6 @@ en:
 
     .toggle-language{
       display: flex;
-      align-items: center;
       justify-content: center;
       font-size: 15px;
       margin-left: auto;

--- a/src/components/TermsPopup.vue
+++ b/src/components/TermsPopup.vue
@@ -381,8 +381,10 @@ en:
 
     .toggle-language{
       display: flex;
+      align-items: center;
       justify-content: center;
       font-size: 15px;
+      line-height: 24px;
       margin-left: auto;
       margin-right: 30px;
     }


### PR DESCRIPTION
Terms of Service의 지구본 옆에 영어면 'English', 한국어면 '한국어'를 띄우도록 수정하였습니다.