### PR TITLE
Fix img tag's max size in comment

### DIFF
--- a/src/components/PostComment.vue
+++ b/src/components/PostComment.vue
@@ -333,6 +333,11 @@ en:
       margin-top: -25px;
     }
 
+    div ::v-deep img{
+      max-width: 300px;
+      max-height: 300px;
+    }
+
     @include breakPoint(mobile) {
       flex-flow: column;
       .button {


### PR DESCRIPTION
댓글에서 <img>로 쓸 수 있는 이미지의 최대 크기를 정하여 일정 크기 이상 커지지 못하게 하였습니다.
현재는 그 제한을 300px로 설정해 두었습니다.