### PR TITLE
Fix/node env ci

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -77,6 +77,6 @@ jobs:
         # be deployed to ECS.
         chmod +x ./.github/workflows/github-actions.sh
         . ./.github/workflows/github-actions.sh
-        docker build --cache-from $ECR/$PROJECT_NAME:$CACHE_DOCKER_TAG --build-arg BACK_ENV -t $ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG .
+        docker build --cache-from $ECR/$PROJECT_NAME:$CACHE_DOCKER_TAG --build-arg VUE_APP_API_MODE -t $ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG"

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -77,6 +77,6 @@ jobs:
         # be deployed to ECS.
         chmod +x ./.github/workflows/github-actions.sh
         . ./.github/workflows/github-actions.sh
-        docker build --cache-from $ECR/$PROJECT_NAME:$CACHE_DOCKER_TAG --build-arg NODE_ENV -t $ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG .
+        docker build --cache-from $ECR/$PROJECT_NAME:$CACHE_DOCKER_TAG --build-arg BACK_ENV -t $ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$DOCKER_TAG"

--- a/.github/workflows/github-actions.sh
+++ b/.github/workflows/github-actions.sh
@@ -10,17 +10,17 @@ if [ ! -z $GITHUB_REF ]; then
         if [ $NAME = "master" ]; then
             export DOCKER_TAG=prod
             export CACHE_DOCKER_TAG=prod
-            export BACK_ENV=production
+            export VUE_APP_API_MODE=production
         else
             # Docker tag에 /가 들어갈 수 없어서 -로 변경
             export DOCKER_TAG=$(echo $NAME | sed -e "s/\//-/g")
             export CACHE_DOCKER_TAG=dev
-            export BACK_ENV=development
+            export VUE_APP_API_MODE=development
         fi
     elif [ $TRIGGER_TYPE = "tags" ]; then
         export DOCKER_TAG=$NAME
         export CACHE_DOCKER_TAG=prod
-        export BACK_ENV=production
+        export VUE_APP_API_MODE=production
     fi
 fi
 

--- a/.github/workflows/github-actions.sh
+++ b/.github/workflows/github-actions.sh
@@ -10,17 +10,17 @@ if [ ! -z $GITHUB_REF ]; then
         if [ $NAME = "master" ]; then
             export DOCKER_TAG=prod
             export CACHE_DOCKER_TAG=prod
-            export NODE_ENV=production
+            export BACK_ENV=production
         else
             # Docker tag에 /가 들어갈 수 없어서 -로 변경
             export DOCKER_TAG=$(echo $NAME | sed -e "s/\//-/g")
             export CACHE_DOCKER_TAG=dev
-            export NODE_ENV=development
+            export BACK_ENV=development
         fi
     elif [ $TRIGGER_TYPE = "tags" ]; then
         export DOCKER_TAG=$NAME
         export CACHE_DOCKER_TAG=prod
-        export NODE_ENV=production
+        export BACK_ENV=production
     fi
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,15 @@ RUN apk del --purge .build-deps
 # Copy other sources
 COPY . .
 
-ARG BACK_ENV
-RUN echo "BACK_ENV=$BACK_ENV" > .env
+ARG VUE_APP_API_MODE
+RUN echo "VUE_APP_API_MODE=$VUE_APP_API_MODE" > .env
 RUN npm run build
 
 FROM nginx:1.19-alpine as newara-web
 ARG WORKDIR
-ARG BACK_ENV
+ARG VUE_APP_API_MODE
 
 WORKDIR /usr/share/nginx/newara
 
 COPY --from=build $WORKDIR/dist ./
-COPY ./nginx/nginx-$BACK_ENV.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx/nginx-$VUE_APP_API_MODE.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk del --purge .build-deps
 COPY . .
 
 ARG BACK_ENV
+RUN echo "BACK_ENV=$BACK_ENV" > .env
 RUN npm run build
 
 FROM nginx:1.19-alpine as newara-web

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ RUN apk del --purge .build-deps
 # Copy other sources
 COPY . .
 
-ARG NODE_ENV
+ARG BACK_ENV
 RUN npm run build
 
 FROM nginx:1.19-alpine as newara-web
 ARG WORKDIR
-ARG NODE_ENV
+ARG BACK_ENV
 
 WORKDIR /usr/share/nginx/newara
 
 COPY --from=build $WORKDIR/dist ./
-COPY ./nginx/nginx-$NODE_ENV.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx/nginx-$BACK_ENV.conf /etc/nginx/conf.d/default.conf

--- a/src/http.js
+++ b/src/http.js
@@ -4,7 +4,7 @@ import router from './router'
 import { getValidatorError } from './helper'
 
 const apiUrl = (function () {
-  if (process.env.BACK_ENV === 'development') {
+  if (process.env.VUE_APP_API_MODE === 'development') {
     return 'https://newara.dev.sparcs.org'
   } else if (process.env.NODE_ENV === 'production') {
     return 'https://newara.sparcs.org'

--- a/src/http.js
+++ b/src/http.js
@@ -4,7 +4,9 @@ import router from './router'
 import { getValidatorError } from './helper'
 
 const apiUrl = (function () {
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.BACK_ENV === 'development') {
+    return 'https://newara.dev.sparcs.org'
+  } else if (process.env.NODE_ENV === 'production') {
     return 'https://newara.sparcs.org'
   } else if (process.env.NODE_ENV === 'development') {
     return 'https://newara.dev.sparcs.org'


### PR DESCRIPTION
기존에 `NODE_ENV` 가 development 일때 dev 서버로 연결되고, `NODE_ENV` 가 production일때 prod 서버 로 연결하도록 설정되었는데, 이렇게 하면 `NODE_ENV`가 production 일때를 dev서버에서 베타테스트 하기 어렵다는 문제가 있었습니다. 또, 앞으로 다룰 service-worker 도 development 환경에서는 작동하지 않기 때문에 api 서버를 구분지을 수 있는 새로운 변수 `VUE_APP_API_MODE`를 도입했습니다. Github Actions를 통해 빌드할 때만 적용됩니다. nginx 파일은 `VUE_APP_API_MODE` 를 따라갑니다.

## 뉴아라 프론트에서 사용하는 환경 정리

### http://localhost:8080 or https://ara-beta-dev.netlify.app
`NODE_ENV=development`, `VUE_APP_API_MODE=undefined` -> dev 서버 연결

### https://newara.dev.sparcs.org
`NODE_ENV=production`, `VUE_APP_API_MODE=development` -> dev 서버 연결

### https://newara.sparcs.org
`NODE_ENV=production`, `VUE_APP_API_MODE=production` -> prod 서버 연결
