### PR TITLE
fix text overflow of myinfo page

### DIFF
--- a/src/views/MyInfo.vue
+++ b/src/views/MyInfo.vue
@@ -486,7 +486,7 @@ en:
   cancel: 'Cancel'
   my-info: 'My info'
   board-my: 'My posts'
-  board-recent: 'Recently viewed'
+  board-recent: 'History'
   board-archive: 'Bookmarks'
   settings : 'Settings'
   setting-change-failed: 'Failed while updating settings.'


### PR DESCRIPTION
myinfo에서 영문으로 전환시 검색바 위치가 틀어지는 것을 고쳤습니다.