### PR TITLE
Fix google translation issue, by replacing editor to vhtml.

### DIFF
--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -178,7 +178,17 @@
     </EditorMenuBar>
 
     <div class="content">
-      <EditorContent :editor="editor" class="editor-content" />
+      <EditorContent
+        v-if="editable"
+        :editor="editor"
+        class="editor-content"
+      />
+      <div
+        v-else
+        :editor="editor"
+        class="editor-content"
+        v-html="getContent()"
+      />
     </div>
 
     <div v-if="editable" class="dialogs">

--- a/src/components/TheTextEditor.vue
+++ b/src/components/TheTextEditor.vue
@@ -187,7 +187,7 @@
         v-else
         :editor="editor"
         class="editor-content"
-        v-html="getContent()"
+        v-html="getVhtmlContent()"
       />
     </div>
 
@@ -298,6 +298,12 @@ export default {
   methods: {
     getContent () {
       return this.editor.getHTML()
+    },
+    getVhtmlContent () {
+      const content = this.editor.getHTML()
+      // Replace <p></p> to <br>(Which done in editor by Prosemirror)
+      const removeRegexP = /<p><\/p>/g
+      return content.replace(removeRegexP, '<br>')
     },
     showLinkDialog () {
       const { commands, schema, view, selection, state: { doc } } = this.editor


### PR DESCRIPTION
Google Translation Extension 문제로 EditorContent를 이용해 내용물을 표기하던 것을 vhtml로 바꾸었습니다.