### PR TITLE
Fix error on going back to post from notification

### DIFF
--- a/src/router/app.js
+++ b/src/router/app.js
@@ -38,7 +38,7 @@ export default [
     component: Post,
     props: true,
     beforeEnter: async (to, from, next) => {
-      if (from.name === 'notifications') {
+      if (from.name === 'notifications' && to.params.notiId) {
         await readNotification(to.params.notiId)
       }
       await authGuard(to, from, next)


### PR DESCRIPTION
알림 읽음 확인을 위해서 notifications에서 알림을 눌러 post로 갈 때 beforeEnter를 사용했는데, 기존 코드의 경우 단순히 notifications에서 post로 이동할 경우가 고려되지 않아 문제가 생깁니다.
이를 해결하기 위해 notiId가 존재하는지 확인하는 과정을 추가했습니다.
