### PR TITLE
Add image resize button

### DIFF
--- a/src/components/TheAttachmentImage.vue
+++ b/src/components/TheAttachmentImage.vue
@@ -1,16 +1,36 @@
 <template>
-  <div>
+  <div class="image-container">
+    <div class="dropdown is-hoverable is-up">
+      <div class="dropdown-trigger material-icons">
+        drag_indicator
+      </div>
+      <div class="dropdown-menu">
+        <div class="dropdown-content">
+          <div
+            v-for="(size, name) in sizes"
+            :key="name"
+            :class="{ 'selected': width === size }"
+            class="dropdown-item"
+            @click="resize(size)"
+          >
+            {{ $t(name) }}
+          </div>
+        </div>
+      </div>
+    </div>
+
     <img
       :src="src"
       :alt="alt"
       :title="title"
+      :width="width"
+      class="image"
       @error="imageLoadError"
     >
   </div>
 </template>
 
 <script>
-
 export default {
   name: 'TheAttachmentImage',
 
@@ -19,6 +39,16 @@ export default {
     updateAttrs: Function,
     view: Object,
     options: Object
+  },
+
+  data () {
+    return {
+      sizes: {
+        small: 250,
+        mid: 500,
+        large: 1000
+      }
+    }
   },
 
   computed: {
@@ -30,6 +60,9 @@ export default {
     },
     title () {
       return this.node.attrs.title
+    },
+    width () {
+      return this.node.attrs.width
     },
     'data-attachment': {
       get () {
@@ -43,7 +76,64 @@ export default {
       if (this.options.errorCallback) {
         this.options.errorCallback()
       }
+    },
+    resize (width) {
+      this.updateAttrs({ width })
     }
   }
 }
 </script>
+
+<i18n>
+ko:
+  small: '작게'
+  mid: '중간'
+  large: '크게'
+en:
+  small: 'small'
+  mid: 'mid'
+  large: 'large'
+</i18n>
+
+<style lang="scss" scoped>
+.image-container {
+  display: flex;
+  flex-flow: row;
+  margin-top: 10px;
+}
+
+.dropdown {
+  &-trigger {
+    width: 25px;
+    height: 25px;
+    margin-left: -25px;
+  }
+
+  &-content {
+    display: flex;
+    flex-flow: row;
+    transform: translate(0, 45px);
+    justify-content: space-around;
+    width: 170px;
+    cursor: pointer;
+    margin: 0;
+  }
+
+  &-menu {
+    margin: 0;
+  }
+
+  &-item {
+    font-size: 15px;
+    width: 50px;
+    padding: 5px;
+    text-align: center;
+    margin: 0;
+  }
+}
+
+.selected {
+  font-weight: bold;
+  color: black;
+}
+</style>

--- a/src/editor/AttachmentImage.js
+++ b/src/editor/AttachmentImage.js
@@ -31,6 +31,9 @@ export default class AttachmentImage extends Node {
         title: {
           default: null
         },
+        width: {
+          default: 500
+        },
         'data-attachment': {
           default: null
         }
@@ -44,6 +47,7 @@ export default class AttachmentImage extends Node {
             src: dom.getAttribute('src'),
             title: dom.getAttribute('title'),
             alt: dom.getAttribute('alt'),
+            width: dom.getAttribute('width'),
             'data-attachment': dom.getAttribute('data-attachment')
           })
         }


### PR DESCRIPTION
이미지 크기를 조절 가능한 버튼을 추가했습니다.
notion과 비슷하게 왼쪽 위 버튼을 Hover하면 세가지 크기를 선택할 수 있습니다.
기존의 사이즈가 지정되지 않은 이미지의 경우 기본 크기로 나옵니다.
