### PR TITLE
Fix front console errors

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -3,7 +3,7 @@ importScripts('https://www.gstatic.com/firebasejs/9.13.0/firebase-messaging-comp
 importScripts('swenv.js')
 
 // TODO: Run `npm run swenv` manually to generate process.env.VUE_APP_FIREBASE_CONFIG in local environment
-const firebaseConfig = JSON.parse(process.env.VUE_APP_FIREBASE_CONFIG || {})
+const firebaseConfig = JSON.parse(process.env.VUE_APP_FIREBASE_CONFIG || '{}')
 
 firebase.initializeApp(firebaseConfig)
 firebase.messaging()

--- a/src/components/PostComment.vue
+++ b/src/components/PostComment.vue
@@ -207,8 +207,11 @@ export default {
       return this.comment.name_type === 0
     },
     isVerified () {
-      const profile = this.comment.created_by?.profile
-      return this.post.parent_board.id === 14 ? profile?.is_school_admin : profile?.is_official
+      if (!this.comment.created_by || !this.post.parent_board) {
+        return false
+      }
+      const profile = this.comment.created_by.profile
+      return this.post.parent_board.id === 14 ? profile.is_school_admin : profile.is_official
     },
     isAuthor () {
       if (this.comment.name_type === 0) {

--- a/src/components/PostCommentEditor.vue
+++ b/src/components/PostCommentEditor.vue
@@ -85,8 +85,11 @@ export default {
       return this.post.name_type !== 0 && this.post.is_mine ? 'author_red' : ''
     },
     isVerified () {
+      if (!this.post.my_comment_profile) {
+        return false
+      }
       const profile = this.post.my_comment_profile.profile
-      return this.post.parent_board.id === 14 ? profile?.is_school_admin : profile?.is_official
+      return this.post.parent_board?.id === 14 ? profile.is_school_admin : profile.is_official
     }
   },
 

--- a/src/components/PostCommentEditor.vue
+++ b/src/components/PostCommentEditor.vue
@@ -85,11 +85,11 @@ export default {
       return this.post.name_type !== 0 && this.post.is_mine ? 'author_red' : ''
     },
     isVerified () {
-      if (!this.post.my_comment_profile) {
+      if (!this.post.my_comment_profile || !this.post.parent_board) {
         return false
       }
       const profile = this.post.my_comment_profile.profile
-      return this.post.parent_board?.id === 14 ? profile.is_school_admin : profile.is_official
+      return this.post.parent_board.id === 14 ? profile.is_school_admin : profile.is_official
     }
   },
 

--- a/src/components/ThePostHeader.vue
+++ b/src/components/ThePostHeader.vue
@@ -7,8 +7,8 @@
           {{ beforeBoardName }}
         </span>
         <span v-if="beforeBoardName === '전체보기' || beforeBoardName === 'All'" class="title__info">
-          <router-link :to="{name: 'board', params: { boardSlug: post.parent_board['slug'] }} " class="title__info">
-            | {{ post.parent_board[`${$i18n.locale}_name`] }}
+          <router-link :to="{name: 'board', params: { boardSlug: boardSlug }} " class="title__info">
+            | {{ boardName }}
           </router-link>
         </span>
       </a>
@@ -118,11 +118,7 @@ export default {
       return this.post.communication_article_status ?? 0
     },
     isCommunicationPost () {
-      if (this.post.parent_board?.id === 14) {
-        return true
-      } else {
-        return false
-      }
+      return this.post.parent_board?.id === 14
     },
     statusText () {
       const t = ['polling', 'preparing', 'answered'][this.status]

--- a/src/components/ThePostHeader.vue
+++ b/src/components/ThePostHeader.vue
@@ -6,8 +6,8 @@
         <span class="title__board--name" @click="hasHistory() ? $router.back() : $router.push(beforeBoard)">
           {{ beforeBoardName }}
         </span>
-        <span v-if="beforeBoardName === '전체보기' || beforeBoardName === 'All'" class="title__info">
-          <router-link :to="{name: 'board', params: { boardSlug: boardSlug }} " class="title__info">
+        <span v-if="beforeBoardName === $t('all')" class="title__info">
+          <router-link :to="{name: 'board', params: { boardSlug }} " class="title__info">
             | {{ boardName }}
           </router-link>
         </span>

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -6,7 +6,7 @@ import * as firebase from 'firebase/app'
 import { getMessaging, getToken, onMessage } from 'firebase/messaging'
 import { updateFCMToken, deleteFCMToken } from './api'
 
-const firebaseConfig = JSON.parse(process.env.VUE_APP_FIREBASE_CONFIG || {})
+const firebaseConfig = JSON.parse(process.env.VUE_APP_FIREBASE_CONFIG || '{}')
 
 const app = firebase.initializeApp(firebaseConfig)
 let acquired = false


### PR DESCRIPTION
https://www.notion.so/sparcs/e027e467dcc04d2596d2b0f9bdfaa0d8

### 1. src/components/SmallBoard.vue

```jsx
TypeError: Cannot read properties of null (reading 'profile')
```

DB article에 created_by.profile: null인 게시물이 있어서 db에 직접 profile을 추가하여 해결했습니다.

### 2. src/components/PostCommentEditor.vue

```jsx
TypeError: Cannot read properties of undefined (reading 'profile')
```

isVerified()에서 post.my_comment_profile이 undefined일 경우 false를 return하도록 변경하였습니다.

또한 post.my_comment_profile이 정의되었다면 post.my_comment_profile.profile 또한 정의되므로 profile 뒤의 Optional chaining operator를 제거하였습니다. 반면 post.parent_board는 undefined일 수 있으므로 Optional chaining operator를 추가하였습니다.

### 3. src/components/ThePostHeader.vue

```jsx
TypeError: Cannot read properties of undefined (reading 'slug')
```

 post.parent_board의 slug와 name을 computed 값을 사용하도록 변경하여 해결했습니다.