### PR TITLE
Update all name_type functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br />
 <br />
 <p align="center">
-  <a href="https://github.com/github_username/repo">
+  <a href="https://newara.sparcs.org">
     <img src="src/assets/ServiceAra.svg" alt="Logo" height="150">
   </a>
   

--- a/src/components/PostComment.vue
+++ b/src/components/PostComment.vue
@@ -204,7 +204,7 @@ export default {
       return this.comment.is_mine
     },
     isRegular () {
-      return this.comment.name_type === 0
+      return this.comment.name_type === 1
     },
     isVerified () {
       if (!this.comment.created_by || !this.post.parent_board) {
@@ -214,7 +214,7 @@ export default {
       return this.post.parent_board.id === 14 ? profile.is_school_admin : profile.is_official
     },
     isAuthor () {
-      if (this.comment.name_type === 0) {
+      if (this.comment.name_type === 1) {
         return false
       }
       return this.post.created_by.id === this.comment.created_by.id

--- a/src/components/PostComment.vue
+++ b/src/components/PostComment.vue
@@ -30,7 +30,7 @@
 
           <span class="comment__time"> {{ date }} </span>
 
-          <div v-if="comment.deleted_at === null && !isHidden" class="dropdown is-right is-hoverable">
+          <div v-if="!isDeleted && !isHidden" class="dropdown is-right is-hoverable">
             <div class="dropdown-trigger">
               <button
                 class="dropdown-button"
@@ -218,6 +218,9 @@ export default {
         return false
       }
       return this.post.created_by.id === this.comment.created_by.id
+    },
+    isDeleted () {
+      return this.comment.is_hidden && this.comment.why_hidden[0] === 'DELETED_CONTENT'
     },
     isHidden () {
       return this.comment.is_hidden

--- a/src/components/PostCommentEditor.vue
+++ b/src/components/PostCommentEditor.vue
@@ -82,7 +82,7 @@ export default {
       return this.post.my_comment_profile ? this.post.my_comment_profile.profile.picture : this.post.created_by?.profile.picture
     },
     authorRed () {
-      return this.post.name_type !== 0 && this.post.is_mine ? 'author_red' : ''
+      return this.post.name_type !== 1 && this.post.is_mine ? 'author_red' : ''
     },
     isVerified () {
       if (!this.post.my_comment_profile || !this.post.parent_board) {

--- a/src/components/PostCommentEditor.vue
+++ b/src/components/PostCommentEditor.vue
@@ -107,6 +107,13 @@ export default {
       if (this.isUploading) {
         return
       }
+      if (!this.content) {
+        this.$store.dispatch('dialog/toast', {
+          type: 'warning',
+          text: this.$t('no-empty')
+        })
+        return
+      }
 
       this.isUploading = true
 
@@ -151,14 +158,16 @@ ko:
   placeholder: '댓글을 작성하세요.'
   new-comment: '등록'
   close-comment: '취소'
-  write-failed: '댓글 작성에 실패하였습니다'
+  write-failed: '댓글 작성을 실패했습니다.'
+  no-empty: '내용을 입력해주세요.'
   author: '글쓴이'
 
 en:
   placeholder: 'Type here...'
-  new-comment: 'Send'
+  new-comment: 'Write'
   close-comment: 'Cancel'
-  write-failed: 'Failed to write comment'
+  write-failed: 'Failed to write comment.'
+  no-empty: 'Please fill in the empty input.'
   author: 'Author'
 </i18n>
 

--- a/src/components/ThePostDetail.vue
+++ b/src/components/ThePostDetail.vue
@@ -75,7 +75,7 @@
       />
       <div :class="{ 'post__buttons--hidden': post.is_hidden }" class="post__buttons-box">
         <div :class="{ 'post__buttons--hidden': post.is_hidden }" class="post__buttons">
-          <template v-if="isMine && (post.can_override_hidden !== false) && post.hidden_at === null">
+          <template v-if="isMine && (post.can_override_hidden !== false) && !post.is_hidden">
             <button class="button" @click="deletePost">
               <i class="like-button__icon material-icons-outlined">
                 delete

--- a/src/components/ThePostDetail.vue
+++ b/src/components/ThePostDetail.vue
@@ -64,7 +64,7 @@
       </div>
     </div>
 
-    <div v-if="!post.is_hidden || !(post.name_type === 1)" class="post__footer">
+    <div v-if="!post.is_hidden || !(post.name_type === 2)" class="post__footer">
       <LikeButton
         v-if="!post.is_hidden"
         :item="post"
@@ -200,10 +200,10 @@ export default {
       return this.post && this.post.is_mine
     },
     isRegular () {
-      return this.post.name_type === 0
+      return this.post.name_type === 1
     },
     isNotRealName () {
-      return this.post.name_type !== 2
+      return this.post.name_type !== 4
     },
     hiddenReason () {
       const title = `<div class="has-text-weight-bold"> ${this.post.why_hidden.map(v => i18n.t(v)).join('<br>')}</div>`

--- a/src/components/ThePostDetail.vue
+++ b/src/components/ThePostDetail.vue
@@ -74,9 +74,9 @@
         @vote="$emit('vote', $event)"
       />
       <div :class="{ 'post__buttons--hidden': post.is_hidden }" class="post__buttons-box">
-        <div :class="{ 'post__buttons--hidden': post.is_hidden }" class="post__buttons">
+        <div class="post__buttons">
           <template v-if="isMine && (post.can_override_hidden !== false) && !post.is_hidden">
-            <button class="button" @click="deletePost">
+            <button class="button mobile-button" @click="deletePost">
               <i class="like-button__icon material-icons-outlined">
                 delete
               </i>
@@ -90,7 +90,7 @@
                   postId
                 }
               }"
-              class="button"
+              class="button mobile-button"
             >
               <i class="like-button__icon material-icons-outlined">
                 edit
@@ -101,7 +101,7 @@
           <template v-else>
             <button
               v-if="isRegular"
-              class="button"
+              class="button mobile-button"
               @click="$emit('block')"
             >
               <i class="like-button__icon material-icons-outlined">
@@ -112,7 +112,7 @@
 
             <button
               v-if="!post.is_hidden && isNotRealName"
-              class="button"
+              class="button mobile-button"
               @click="$emit('report')"
             >
               <i class="like-button__icon material-icons-outlined">
@@ -122,7 +122,7 @@
             </button>
           </template>
         </div>
-        <div :class="{ 'post__buttons--hidden': post.is_hidden }" class="post__buttons">
+        <div class="post__buttons">
           <button
             v-if="!post.is_hidden"
             class="button"
@@ -315,7 +315,6 @@ en:
     align-items: center;
     justify-content: flex-end;
     flex-wrap: wrap;
-    margin-top: 10px;
     @include breakPoint(mobile) {
       width: 100%;
       justify-content: space-between;
@@ -327,6 +326,7 @@ en:
     align-items: center;
     justify-content: flex-end;
     flex-wrap: wrap;
+    margin-top: 10px;
 
     &--hidden {
       flex: 1;
@@ -347,15 +347,25 @@ en:
         color: white;
       }
 
-      & > .button-text {
-        @include breakPoint(mobile) {
-          display: none;
-        }
+      .button-text {
+        cursor: pointer;
       }
 
       .like-button__icon {
         margin-right: 5px;
         font-size: 18px;
+      }
+    }
+
+    & > .mobile-button {
+      @include breakPoint(mobile) {
+        .button-text {
+          display: none;
+        }
+        .like-button__icon {
+          margin-right: 0px;
+          font-size: 18px;
+        }
       }
     }
   }

--- a/src/components/ThePostHeader.vue
+++ b/src/components/ThePostHeader.vue
@@ -150,7 +150,7 @@ export default {
       return this.post.title
     },
     isRegular () {
-      return this.post.name_type === 0
+      return this.post.name_type === 1
     },
     beforeBoard () {
       const { from_view: fromView, topic_id: topicId, current } = this.$route.query

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,21 +5,6 @@ import store from '@/store'
 import http from '@/http'
 import i18n from '@/i18n'
 import '@/registerServiceWorker'
-const VueProgressBar = require('vue-progressbar')
-
-const options = {
-  color: '#f4b9b9',
-  failedColor: '#b22020',
-  thickness: '5px',
-  transition: {
-    speed: '0.1s',
-    opacity: '0.3s',
-    termination: 300
-  },
-  autoRevert: true,
-  location: 'top'
-}
-Vue.use(VueProgressBar, options)
 
 Vue.prototype.$http = http
 

--- a/src/progressBar.js
+++ b/src/progressBar.js
@@ -1,0 +1,19 @@
+import Vue from 'vue'
+const VueProgressBar = require('vue-progressbar')
+
+const options = {
+  color: '#f4b9b9',
+  failedColor: '#b22020',
+  thickness: '5px',
+  transition: {
+    speed: '0.1s',
+    opacity: '0.3s',
+    termination: 300
+  },
+  autoRevert: true,
+  location: 'top'
+}
+Vue.use(VueProgressBar, options)
+
+const progressBar = new Vue()
+export default progressBar

--- a/src/views/helper.js
+++ b/src/views/helper.js
@@ -1,5 +1,6 @@
 import i18n from '@/i18n'
 import store from '@/store'
+import progressBar from '@/progressBar'
 
 export const fetchWithProgress = async (targets, errText) => {
   store.dispatch('fetch/startProgress')
@@ -16,7 +17,7 @@ export const fetchWithProgress = async (targets, errText) => {
         text: i18n.t(errText) + (err.apierr ? '\n' + err.apierr : '')
       })
     }
-
+    progressBar.$Progress.fail()
     store.dispatch('fetch/endProgress')
 
     throw err


### PR DESCRIPTION
517fb11: https://github.com/sparcs-kaist/new-ara-api/pull/384 에 따라 `name_type`을 _(0: 기본, 1: 익명, 2: 실명)_ 에서 _(1: 기본, 2: 익명, 4: 실명)_ 으로 변경
dcf1358: 댓글 드롭다운 메뉴가 나오지 않는 버그 수정
4172fa6: 모바일에서 게시물 버튼 css 수정
aed0d10: 빈 댓글을 POST 하지 않도록 수정
f0e3507: 프로그레스 바에 fetch 실패 경우 처리