### PR TITLE
Fix mobile buttons css

### DIFF
--- a/src/components/ThePostDetail.vue
+++ b/src/components/ThePostDetail.vue
@@ -125,20 +125,20 @@
         <div class="post__buttons">
           <button
             v-if="!post.is_hidden"
-            class="button"
+            class="button mobile-button"
             @click="$emit('copy-url')"
           >
             <i class="like-button__icon material-icons-outlined">content_copy</i>
-            {{ $t('copy-url') }}
+            <label class="button-text">{{ $t('copy-url') }}</label>
           </button>
           <button
             v-if="!post.is_hidden"
-            class="button archive-button"
+            class="button archive-button mobile-button"
             :class="{ 'button--clicked': post.my_scrap }"
             @click="$emit('archive')"
           >
             <i class="like-button__icon material-icons-outlined">add</i>
-            {{ $t('archive') }}
+            <label class="button-text">{{ $t('archive') }}</label>
           </button>
         </div>
       </div>


### PR DESCRIPTION
이번에 배포할때 모바일 뷰 테스트를 제대로 못했더니 게시물 버튼들 특정 기기에서 줄바꿈이 되네요.. 보기 안좋아서 hotfix로 배포할 수 있으면 좋을것 같은데 어떻게 생각하시나요


| releases/3.0.1 | fix/mobile-button |
|----------|----------|
| ![image](https://github.com/sparcs-kaist/new-ara-web/assets/87213416/ad56c9cb-ac88-4444-ac44-f57918dbe5b3) | ![image](https://github.com/sparcs-kaist/new-ara-web/assets/87213416/845cc760-f432-42c1-9360-54eb8bc95c24) |
