### PR TITLE
Fix GA error

### DIFF
--- a/nginx/nginx-production.conf
+++ b/nginx/nginx-production.conf
@@ -16,8 +16,9 @@ server {
     set $CSP "${CSP}object-src 'self'; ";                                               # Disallow Objects
     set $CSP "${CSP}connect-src 'self' *.channel.io *.sentry.io wss://*.channel.io ";   # Connect rules for channeltalk (1/2)
     set $CSP "${CSP}wss://*.desk-ws.channel.io wss://*.front-ws.channel.io ";           # Connect rules for channeltalk (2/2)
-    set $CSP "${CSP}https://www.google-analytics.com https://analytics.google.com; ";   # Connect rules for google analytics
-    
+    set $CSP "${CSP}https://www.google-analytics.com https://analytics.google.com ";    # Connect rules for google analytics (1/2)
+    set $CSP "${CSP}https://stats.g.doubleclick.net; ";                                 # Connect rules for google analytics (2/2)
+
     set $CSP "${CSP}img-src * data: blob:; ";                                            # Image rules for new-ara (allow all, data, blobs)
     
     set $CSP "${CSP}script-src 'self' ";                                                 # Script rules for new-ara


### PR DESCRIPTION
#400 배포 후 GA 쓰려면 `https://stats.g.doubleclick.net` 도 connect-src 에 추가해줘야 하는걸 발견..ㅠ
배포 자동화가 시급합니다 휠팀한테 부탁해볼까요 (!!)