### PR TITLE
Term-popup fix : 비동기 로딩

### DIFF
--- a/src/views/Terms.vue
+++ b/src/views/Terms.vue
@@ -1,20 +1,40 @@
 <template>
   <TheLayout>
-    <TermsPopup />
+    <!-- 비동기적으로 TermsPopup을 로드 -->
+    <component :is="TermsPopup" />
   </TheLayout>
 </template>
 
 <script>
 import store from '@/store'
-import TermsPopup from '@/components/TermsPopup.vue'
 import TheLayout from '@/components/TheLayout.vue'
 
 export default {
   name: 'Terms',
 
   components: {
-    TermsPopup,
     TheLayout
+  },
+
+  data () {
+    return {
+      TermsPopup: null // 비동기적으로 로드될 컴포넌트
+    }
+  },
+
+  mounted () {
+    this.loadTermsPopup()
+  },
+
+  methods: {
+    async loadTermsPopup () {
+      try {
+        const { default: TermsPopup } = await import('@/components/TermsPopup.vue')
+        this.TermsPopup = TermsPopup // 로드된 컴포넌트를 data에 저장하여 렌더링
+      } catch (error) {
+        console.error('Failed to load TermsPopup', error)
+      }
+    }
   },
 
   beforeRouteEnter (from, to, next) {


### PR DESCRIPTION
팝업이 뜨지 않는 에러의 경우 Vue에서 dom을 로딩할 때 부모 컴포넌트와 자식 컴포넌트간의 로딩 순서가 바뀌어 생긴 문제였다. 이를 해결하기 위해 로딩이 다 끝난 이후 자식 컴포넌트를 비동기로 다시 로드하는 로직을 추가하였다.